### PR TITLE
Fix Syllabi link url

### DIFF
--- a/js/courseCatalog.js
+++ b/js/courseCatalog.js
@@ -91,7 +91,7 @@ function buildCourseLinks(course_info) {
 	} = course_info
 	links = {
 		"textbook": `https://www.universitycoop.com/adoption-search-results?sn=${semester_code}__${department}__${number}__${unique}`,
-		"syllabi": `https://utdirect.utexas.edu/apps/student/coursedocs/nlogon/?semester=&department=${department}&course_number=${number}&course_title=&unique=&instructor_first=&instructor_last=${prof_name}&course_type=In+Residence&search=Search`,
+		"syllabi": `https://utdirect.utexas.edu/apps/student/coursedocs/nlogon/?year=&semester=&department=${department}&course_number=${number}&course_title=&unique=&instructor_first=&instructor_last=${prof_name}&course_type=In+Residence&search=Search`,
 		//default ones (before first name can be used)
 		"rate_my_prof": "http://www.ratemyprofessors.com/campusRatings.jsp?sid=1255",
 		"ecis": "http://utdirect.utexas.edu/ctl/ecis/results/index.WBX?"

--- a/js/utPlanner.js
+++ b/js/utPlanner.js
@@ -65,7 +65,7 @@ function buildCourseLinks(course_info) {
     } = course_info
     links = {
         "textbook": `https://www.universitycoop.com/adoption-search-results?sn=${semester_code}__${department}__${number}__${unique}`,
-        "syllabi": `https://utdirect.utexas.edu/apps/student/coursedocs/nlogon/?semester=&department=${department}&course_number=${number}&course_title=&unique=&instructor_first=&instructor_last=${prof_name}&course_type=In+Residence&search=Search`,
+        "syllabi": `https://utdirect.utexas.edu/apps/student/coursedocs/nlogon/?year=&semester=&department=${department}&course_number=${number}&course_title=&unique=&instructor_first=&instructor_last=${prof_name}&course_type=In+Residence&search=Search`,
     }
     course_info["links"] = links;
     return course_info;


### PR DESCRIPTION
It looks like UT has changed their syllabi link and added a year field, without that the search link is broken.