### PR TITLE
feat: dividers in calendar bottom bar

### DIFF
--- a/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
+++ b/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 
 import CalendarMonthIcon from '~icons/material-symbols/calendar-month';
 import ImageIcon from '~icons/material-symbols/image';
+import Divider from '../../common/Divider/Divider';
 
 import type { CalendarCourseCellProps } from '../CalendarCourseCell/CalendarCourseCell';
 import CalendarCourseBlock from '../CalendarCourseCell/CalendarCourseCell';
@@ -126,9 +127,11 @@ export const CalendarBottomBar = ({ courses, calendarRef }: CalendarBottomBarPro
                 </div>
             </div>
             <div className='flex items-center pl-2.5 pr-7.5'>
+                <Divider orientation='vertical' size='1rem' className='mx-1.25' />
                 <Button variant='single' color='ut-black' icon={CalendarMonthIcon} onClick={saveAsCal}>
                     Save as .CAL
                 </Button>
+                <Divider orientation='vertical' size='1rem' className='mx-1.25' />
                 <Button variant='single' color='ut-black' icon={ImageIcon} onClick={saveAsPng}>
                     Save as .PNG
                 </Button>

--- a/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
+++ b/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
@@ -1,5 +1,6 @@
 import { UserScheduleStore } from '@shared/storage/UserScheduleStore';
 import { Button } from '@views/components/common/Button/Button';
+import Divider from '@views/components/common/Divider/Divider';
 import Text from '@views/components/common/Text/Text';
 import clsx from 'clsx';
 import { toPng } from 'html-to-image';
@@ -7,7 +8,6 @@ import React from 'react';
 
 import CalendarMonthIcon from '~icons/material-symbols/calendar-month';
 import ImageIcon from '~icons/material-symbols/image';
-import Divider from '../../common/Divider/Divider';
 
 import type { CalendarCourseCellProps } from '../CalendarCourseCell/CalendarCourseCell';
 import CalendarCourseBlock from '../CalendarCourseCell/CalendarCourseCell';


### PR DESCRIPTION
Before:
<img width="430" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/c273bb82-713a-4d38-b951-4d8fe9f643d5">

After:
<img width="604" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/01e9d2dc-7596-4877-9639-4837f4202ff6">

(red outline comes from storybook)

This is to reflect the Figma design

<img width="400" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/d8ca362e-b8d8-4db1-a3d8-58aed4017e2c">

originally, dividers were not included because dividers hadn't been created yet