### PR TITLE
fix: remove extra spacing on CalendarHeader

### DIFF
--- a/src/views/components/calendar/CalendarHeader/CalenderHeader.tsx
+++ b/src/views/components/calendar/CalendarHeader/CalenderHeader.tsx
@@ -19,7 +19,7 @@ const handleOpenOptions = async () => {
 };
 
 const CalendarHeader = ({ totalHours, totalCourses, scheduleName }) => (
-    <div className='min-h-79px min-w-672px w-full flex px-0 py-15'>
+    <div className='min-h-79px min-w-672px w-full flex px-0'>
         <div className='flex flex-row gap-20'>
             <div className='flex gap-10'>
                 <div className='flex gap-1'>


### PR DESCRIPTION
literally removed one style (py-15)
before:
![image](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/93348668/ef3fc291-088d-4c2f-8512-57a097d25a78)

after:
![image](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/93348668/41f3ce3c-bcfd-442c-b2d8-4ca8af5129f1)
