### PR TITLE
fix: options page

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,0 +1,1 @@
+src/pages/options/index.html

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -25,7 +25,7 @@ const manifest = defineManifest(async () => ({
     name: `${packageJson.displayName ?? packageJson.name}${mode === 'development' ? ' (dev)' : ''}`,
     version: `${major}.${minor}.${patch}.${label}`,
     description: packageJson.description,
-    options_page: 'src/pages/options/index.html',
+    options_page: 'options.html',
     background: { service_worker: 'src/pages/background/background.ts' },
     permissions: ['storage', 'unlimitedStorage', 'background', 'scripting'],
     host_permissions: process.env.MODE === 'development' ? [...HOST_PERMISSIONS, '<all_urls>'] : HOST_PERMISSIONS,

--- a/src/pages/options/index.html
+++ b/src/pages/options/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
-        <title>Popup</title>
+        <title>UTRP Options</title>
     </head>
 
     <body>

--- a/src/views/components/PopupMain.tsx
+++ b/src/views/components/PopupMain.tsx
@@ -57,7 +57,7 @@ export default function PopupMain(): JSX.Element {
     ));
 
     const handleOpenOptions = async () => {
-        const url = chrome.runtime.getURL('/src/pages/options/index.html');
+        const url = chrome.runtime.getURL('/options.html');
         await openTabFromContentScript(url);
     };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -136,6 +136,10 @@ export default defineConfig({
                 target: 'http://localhost:5173',
                 rewrite: path => path.replace('calendar', 'src/pages/calendar/index'),
             },
+            '/options.html': {
+                target: 'http://localhost:5173',
+                rewrite: path => path.replace('options', 'src/pages/options/index'),
+            },
         },
     },
     build: {
@@ -143,6 +147,7 @@ export default defineConfig({
             input: {
                 debug: 'src/pages/debug/index.html',
                 calendar: 'src/pages/calendar/index.html',
+                options: 'src/pages/options/index.html',
             },
             // output: {
             //     entryFileNames: `[name].js`, // otherwise it will add the hash


### PR DESCRIPTION
Fix the options page not linking properly by using a symlink to trick it into building.

Alternatively we could just move options outwards from the src/pages OR not rename it at all. I don't think it's possible to both rename it in the vite config and use it's path in the manifest file