### PR TITLE
fix: non-determinstic options page generation

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,1 +1,0 @@
-src/pages/options/index.html

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -25,7 +25,7 @@ const manifest = defineManifest(async () => ({
     name: `${packageJson.displayName ?? packageJson.name}${mode === 'development' ? ' (dev)' : ''}`,
     version: `${major}.${minor}.${patch}.${label}`,
     description: packageJson.description,
-    options_page: 'options.html',
+    options_page: 'src/pages/options/index.html',
     background: { service_worker: 'src/pages/background/background.ts' },
     permissions: ['storage', 'unlimitedStorage', 'background', 'scripting'],
     host_permissions: process.env.MODE === 'development' ? [...HOST_PERMISSIONS, '<all_urls>'] : HOST_PERMISSIONS,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,25 @@ const renameFile = (source: string, destination: string): Plugin => {
     };
 };
 
+const fixManifestOptionsPage = () => ({
+    name: 'fix-manifest-options-page',
+    apply: 'build' as const,
+    enforce: 'post' as const,
+    generateBundle(_, bundle) {
+        // Find the manifest.json in the generated bundle
+        for (const fileName of Object.keys(bundle)) {
+            if (fileName.startsWith('assets/crx-manifest')) {
+                const chunk = bundle[fileName];
+                console.log(chunk.code);
+                chunk.code = chunk.code.replace(
+                    /"options_page":"src\/pages\/options\/index.html"/,
+                    `"options_page":"options.html"`
+                );
+            }
+        }
+    },
+});
+
 let config: ResolvedConfig;
 let server: ViteDevServer;
 
@@ -52,6 +71,7 @@ export default defineConfig({
         UnoCSS(),
         Icons({ compiler: 'jsx', jsx: 'react' }),
         crx({ manifest }),
+        fixManifestOptionsPage(),
         inspect(),
         {
             name: 'public-transform',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,15 +47,14 @@ const fixManifestOptionsPage = () => ({
     apply: 'build' as const,
     enforce: 'post' as const,
     generateBundle(_, bundle) {
-        // Find the manifest.json in the generated bundle
         for (const fileName of Object.keys(bundle)) {
             if (fileName.startsWith('assets/crx-manifest')) {
                 const chunk = bundle[fileName];
-                console.log(chunk.code);
                 chunk.code = chunk.code.replace(
                     /"options_page":"src\/pages\/options\/index.html"/,
                     `"options_page":"options.html"`
                 );
+                break;
             }
         }
     },


### PR DESCRIPTION
Fix the issue of the symlink hack being non-deterministic. Instead we use a custom plugin to edit the manifest and manually set the options page link at the end of the build.