### PR TITLE
fix: cannot use tailwind on course schedule page

### DIFF
--- a/src/views/components/CourseCatalogMain.tsx
+++ b/src/views/components/CourseCatalogMain.tsx
@@ -1,5 +1,4 @@
 import type { Course, ScrapedRow } from '@shared/types/Course';
-import ExtensionRoot from '@views/components/common/ExtensionRoot/ExtensionRoot';
 import AutoLoad from '@views/components/injected/AutoLoad/AutoLoad';
 import CourseCatalogInjectedPopup from '@views/components/injected/CourseCatalogInjectedPopup/CourseCatalogInjectedPopup';
 import RecruitmentBanner from '@views/components/injected/RecruitmentBanner/RecruitmentBanner';
@@ -13,6 +12,8 @@ import getCourseTableRows from '@views/lib/getCourseTableRows';
 import type { SiteSupportType } from '@views/lib/getSiteSupport';
 import { populateSearchInputs } from '@views/lib/populateSearchInputs';
 import React, { useEffect, useState } from 'react';
+
+import ExtensionRootAlternate from './common/ExtensionRootAlternate/ExtensionRootAlternate';
 
 interface Props {
     support: Extract<SiteSupportType, 'COURSE_CATALOG_DETAILS' | 'COURSE_CATALOG_LIST'>;
@@ -60,7 +61,7 @@ export default function CourseCatalogMain({ support }: Props): JSX.Element {
     }
 
     return (
-        <ExtensionRoot>
+        <ExtensionRootAlternate>
             <RecruitmentBanner />
             <TableHead>Plus</TableHead>
             {rows.map((row, i) => {
@@ -86,6 +87,6 @@ export default function CourseCatalogMain({ support }: Props): JSX.Element {
                 />
             )}
             <AutoLoad addRows={addRows} />
-        </ExtensionRoot>
+        </ExtensionRootAlternate>
     );
 }

--- a/src/views/components/common/ExtensionRootAlternate/ExtensionRootAlternate.tsx
+++ b/src/views/components/common/ExtensionRootAlternate/ExtensionRootAlternate.tsx
@@ -1,0 +1,19 @@
+import 'uno.css';
+
+import React from 'react';
+
+import styles from '../ExtensionRoot/ExtensionRoot.module.scss';
+
+interface Props {
+    testId?: string;
+}
+/**
+ * A wrapper component for the extension elements that adds some basic styling to them
+ */
+export default function ExtensionRootAlternate(props: React.PropsWithChildren<Props>): JSX.Element {
+    return (
+        <div className={styles.extensionRoot} data-testid={props.testId}>
+            {props.children}
+        </div>
+    );
+}


### PR DESCRIPTION
Using tailwind on the course schedule pages causes weird visual bugs such as no bounding boxes for courses and deformed buttons. If there is another workaround to this without removing tailwind for this part, let me know and we can implement that instead - but I could not find another solution for now.