### PR TITLE
feat: calendar schedules list functionality

### DIFF
--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -1,0 +1,24 @@
+name: Type Check
+
+on: [push, pull_request]
+
+jobs:
+    type-check:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v3
+              with:
+                  version: 8
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Run tests
+              run: pnpm run check-types

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "prettier:fix": "prettier src --write",
         "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",
         "lint:fix": "eslint src --ext ts,tsx --report-unused-disable-directives --fix",
+        "check-types": "tsc --noEmit",
         "test": "vitest",
         "test:ui": "vitest --ui",
         "coverage": "vitest run --coverage",

--- a/src/pages/background/background.ts
+++ b/src/pages/background/background.ts
@@ -1,4 +1,6 @@
 import type { BACKGROUND_MESSAGES } from '@shared/messages';
+import { UserScheduleStore } from '@shared/storage/UserScheduleStore';
+import updateBadgeText from '@shared/util/updateBadgeText';
 import { MessageListener } from 'chrome-extension-toolkit';
 
 import onInstall from './events/onInstall';
@@ -37,3 +39,19 @@ const messageListener = new MessageListener<BACKGROUND_MESSAGES>({
 });
 
 messageListener.listen();
+
+UserScheduleStore.listen('schedules', async schedules => {
+    const index = await UserScheduleStore.get('activeIndex');
+    const numCourses = schedules[index]?.courses?.length;
+    if (!numCourses) return;
+
+    updateBadgeText(numCourses);
+});
+
+UserScheduleStore.listen('activeIndex', async ({ newValue }) => {
+    const schedules = await UserScheduleStore.get('schedules');
+    const numCourses = schedules[newValue]?.courses?.length;
+    if (!numCourses) return;
+
+    updateBadgeText(numCourses);
+});

--- a/src/shared/types/Course.ts
+++ b/src/shared/types/Course.ts
@@ -73,11 +73,16 @@ export class Course {
     instructionMode: InstructionMode;
     /** Which semester is the course from */
     semester: Semester;
+    /** Unix timestamp of when the course was last scraped */
+    scrapedAt: number;
 
     constructor(course: Serialized<Course>) {
         Object.assign(this, course);
         this.schedule = new CourseSchedule(course.schedule);
         this.instructors = course.instructors.map(i => new Instructor(i));
+        if (!course.scrapedAt) {
+            this.scrapedAt = Date.now();
+        }
     }
 
     /**

--- a/src/shared/types/CourseSchedule.ts
+++ b/src/shared/types/CourseSchedule.ts
@@ -10,14 +10,12 @@ export class CourseSchedule {
     meetings: CourseMeeting[] = [];
 
     constructor(courseSchedule?: Serialized<CourseSchedule>) {
-        if (!courseSchedule) {
+        if (!courseSchedule || courseSchedule.meetings === undefined) {
+            this.meetings = [];
             return;
         }
-        Object.assign(this, courseSchedule);
-        this.meetings = [];
-        for (let meeting of courseSchedule.meetings) {
-            this.meetings.push(new CourseMeeting(meeting));
-        }
+
+        this.meetings = courseSchedule.meetings.map(meeting => new CourseMeeting(meeting));
     }
 
     /**

--- a/src/shared/util/updateBadgeText.ts
+++ b/src/shared/util/updateBadgeText.ts
@@ -1,0 +1,34 @@
+import { colors } from './themeColors';
+import { MILLISECOND } from './time';
+
+/** How long should we flash the badge when it changes value */
+export const POPUP_FLASH_TIME = 200 * MILLISECOND;
+
+/** The maximum number to show in the badge, after which we show a '+' */
+export const BADGE_LIMIT = 10;
+
+/**
+ * Updates the badge text based on the given value.
+ * If the value is greater than the badge limit, it sets the badge text to the badge limit followed by a '+'.
+ * @param value - The value to be displayed in the badge.
+ */
+export default function updateBadgeText(value: number): void {
+    let badgeText = '';
+    if (value > 0) {
+        if (value > BADGE_LIMIT) {
+            badgeText = `${BADGE_LIMIT}+`;
+        } else {
+            badgeText = `${value}`;
+        }
+    }
+    chrome.action.setBadgeText({ text: badgeText });
+    flashBadgeColor();
+}
+
+/**
+ * Flashes the badge color by setting the badge background color to a color and then resetting it after a short delay.
+ */
+function flashBadgeColor() {
+    chrome.action.setBadgeBackgroundColor({ color: colors.ut.burntorange });
+    setTimeout(() => chrome.action.setBadgeBackgroundColor({ color: colors.ut.orange }), POPUP_FLASH_TIME);
+}

--- a/src/stories/components/ConflictsWithWarning.stories.tsx
+++ b/src/stories/components/ConflictsWithWarning.stories.tsx
@@ -44,6 +44,7 @@ export const ExampleCourse: Course = new Course({
     status: Status.WAITLISTED,
     uniqueId: 12345,
     url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20242/12345/',
+    scrapedAt: Date.now(),
 });
 export const ExampleCourse2: Course = new Course({
     courseName: 'PRINCIPLES OF COMPUTER SYSTEMS',
@@ -90,6 +91,7 @@ export const ExampleCourse2: Course = new Course({
     status: Status.WAITLISTED,
     uniqueId: 67890,
     url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20242/12345/',
+    scrapedAt: Date.now(),
 });
 
 const meta = {

--- a/src/stories/components/List.stories.tsx
+++ b/src/stories/components/List.stories.tsx
@@ -25,6 +25,7 @@ const generateCourses = (count: number): Course[] => {
             courseName: 'ELEMS OF COMPTRS/PROGRAMMNG-WB',
             creditHours: 3,
             department: 'C S',
+            scrapedAt: Date.now(),
             description: [
                 'Problem solving and fundamental algorithms for various applications in science, business, and on the World Wide Web, and introductory programming in a modern object-oriented programming language.',
                 'Only one of the following may be counted: Computer Science 303E, 312, 312H. Credit for Computer Science 303E may not be earned after a student has received credit for Computer Science 314, or 314H. May not be counted toward a degree in computer science.',

--- a/src/stories/components/PopupCourseBlock.stories.tsx
+++ b/src/stories/components/PopupCourseBlock.stories.tsx
@@ -17,6 +17,7 @@ export const ExampleCourse: Course = new Course({
     courseName: 'ELEMS OF COMPTRS/PROGRAMMNG-WB',
     creditHours: 3,
     department: 'C S',
+    scrapedAt: Date.now(),
     description: [
         'Problem solving and fundamental algorithms for various applications in science, business, and on the World Wide Web, and introductory programming in a modern object-oriented programming language.',
         'Only one of the following may be counted: Computer Science 303E, 312, 312H. Credit for Computer Science 303E may not be earned after a student has received credit for Computer Science 314, or 314H. May not be counted toward a degree in computer science.',

--- a/src/stories/components/Prompt.stories.tsx
+++ b/src/stories/components/Prompt.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '@views/components/common/Button/Button';
+import type { PromptDialogProps } from '@views/components/common/Prompt/Prompt';
+import PromptDialog from '@views/components/common/Prompt/Prompt';
+import Text from '@views/components/common/Text/Text';
+import React from 'react';
+
+const meta = {
+    title: 'Components/Common/Prompt',
+    component: PromptDialog,
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        isOpen: { control: 'boolean' },
+        title: { control: 'object' },
+        content: { control: 'object' },
+        children: { control: 'object' },
+    },
+} satisfies Meta<typeof PromptDialog>;
+export default meta;
+
+const PromptDialogWithButton = ({ children, ...args }: PromptDialogProps) => {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const handleOpen = () => setIsOpen(true);
+    const handleClose = () => setIsOpen(false);
+    const { title, content } = args;
+
+    const childrenWithHandleClose: React.ReactElement[] = children.map(child => {
+        if (child.type === Button) {
+            return React.cloneElement(child, { onClick: () => handleClose() } as React.HTMLAttributes<HTMLElement>);
+        }
+        return child;
+    });
+
+    return (
+        <div className='h-screen w-screen flex items-center justify-center'>
+            <Button variant='filled' color='ut-burntorange' onClick={handleOpen}>
+                Open Prompt
+            </Button>
+            <PromptDialog {...args} isOpen={isOpen} onClose={handleClose} title={title} content={content}>
+                {childrenWithHandleClose}
+            </PromptDialog>
+        </div>
+    );
+};
+
+export const AreYouSure: StoryObj<PromptDialogProps> = {
+    render: args => <PromptDialogWithButton {...args} />,
+    args: {
+        title: <Text variant='h2'>Are you sure?</Text>,
+        content: (
+            <Text variant='p'>
+                Deleting Main Schedule is permanent and will remove all added courses and schedules.
+            </Text>
+        ),
+        children: [
+            <Button key='yes' variant='single' color='ut-burntorange'>
+                Yes
+            </Button>,
+            <Button key='no' variant='single' color='ut-black'>
+                No
+            </Button>,
+        ],
+    },
+};
+
+export const YouHave10ActiveSchedules: StoryObj<PromptDialogProps> = {
+    render: args => <PromptDialogWithButton {...args} />,
+    args: {
+        title: <Text variant='h2'>You have 10 active schedules!</Text>,
+        content: (
+            <Text variant='p'>
+                To encourage organization, please consider removing some unused schedules you may have.
+            </Text>
+        ),
+        children: [
+            <Button key='yes' variant='single' color='ut-black'>
+                I understand
+            </Button>,
+        ],
+    },
+};
+
+export const WelcomeToUTRPV2: StoryObj<PromptDialogProps> = {
+    render: args => <PromptDialogWithButton {...args} />,
+    args: {
+        title: <Text variant='h2'>Welcome to UTRP V2!</Text>,
+        content: (
+            <Text variant='p'>
+                You may have already began planning your Summer or Fall schedule. To migrate your courses into v2.0
+                please select “Migrate,” or start fresh.
+            </Text>
+        ),
+        children: [
+            <Button key='migrate' variant='single' color='ut-black'>
+                Don&apos;t Migrate
+            </Button>,
+            <Button key='start-fresh' variant='single' color='ut-burntorange'>
+                Migrate
+            </Button>,
+        ],
+    },
+};

--- a/src/stories/components/calendar/CalendarBottomBar.stories.tsx
+++ b/src/stories/components/calendar/CalendarBottomBar.stories.tsx
@@ -25,6 +25,7 @@ const exampleGovCourse: Course = new Course({
     schedule: {
         meetings: [],
     },
+    scrapedAt: Date.now(),
     semester: {
         code: '12345',
         season: 'Spring',
@@ -43,6 +44,7 @@ const examplePsyCourse: Course = new Course({
     flags: ['no flag for you >:)'],
     fullName: 'PSY 317L Yada yada',
     instructionMode: 'Online',
+    scrapedAt: Date.now(),
     instructors: [
         new Instructor({
             firstName: 'Bevo',

--- a/src/stories/components/calendar/CalendarCourse.stories.tsx
+++ b/src/stories/components/calendar/CalendarCourse.stories.tsx
@@ -55,6 +55,7 @@ export const Default: Story = {
                 year: 2024,
                 season: 'Spring',
             },
+            scrapedAt: Date.now(),
         }),
         meetingIdx: 0,
         color: 'red',

--- a/src/stories/components/calendar/CalendarSchedules.stories.tsx
+++ b/src/stories/components/calendar/CalendarSchedules.stories.tsx
@@ -61,6 +61,7 @@ const schedules = [
                     year: 2024,
                     season: 'Fall',
                 },
+                scrapedAt: Date.now(),
             }),
         ],
         name: 'Main Schedule',
@@ -98,6 +99,7 @@ const schedules = [
                     year: 2024,
                     season: 'Spring',
                 },
+                scrapedAt: Date.now(),
             }),
             new Course({
                 uniqueId: 123,
@@ -129,6 +131,7 @@ const schedules = [
                     year: 2024,
                     season: 'Fall',
                 },
+                scrapedAt: Date.now(),
             }),
         ],
         name: 'Backup #3',

--- a/src/stories/injected/mocked.ts
+++ b/src/stories/injected/mocked.ts
@@ -17,6 +17,7 @@ export const exampleCourse: Course = new Course({
     flags: ['Quantitative Reasoning'],
     fullName: 'C S 303E ELEMS OF COMPTRS/PROGRAMMNG-WB',
     instructionMode: 'Online',
+    scrapedAt: Date.now(),
     instructors: [
         new Instructor({
             firstName: 'William',
@@ -100,6 +101,7 @@ export const bevoCourse: Course = new Course({
         year: 2024,
         season: 'Spring',
     },
+    scrapedAt: Date.now(),
 });
 
 export const bevoScheule: UserSchedule = new UserSchedule({
@@ -151,6 +153,7 @@ export const MikeScottCS314Course: Course = new Course({
         year: 2024,
         season: 'Spring',
     },
+    scrapedAt: Date.now(),
 });
 
 export const MikeScottCS314Schedule: UserSchedule = new UserSchedule({

--- a/src/views/components/CourseCatalogMain.tsx
+++ b/src/views/components/CourseCatalogMain.tsx
@@ -5,7 +5,7 @@ import CourseCatalogInjectedPopup from '@views/components/injected/CourseCatalog
 import RecruitmentBanner from '@views/components/injected/RecruitmentBanner/RecruitmentBanner';
 import TableHead from '@views/components/injected/TableHead';
 import TableRow from '@views/components/injected/TableRow/TableRow';
-import TableSubheading from '@views/components/injected/TableSubheading/TableSubheading';
+// import TableSubheading from '@views/components/injected/TableSubheading/TableSubheading';
 import { useKeyPress } from '@views/hooks/useKeyPress';
 import useSchedules from '@views/hooks/useSchedules';
 import { CourseCatalogScraper } from '@views/lib/CourseCatalogScraper';
@@ -63,21 +63,18 @@ export default function CourseCatalogMain({ support }: Props): JSX.Element {
         <ExtensionRoot>
             <RecruitmentBanner />
             <TableHead>Plus</TableHead>
-            {rows.map((row, i) => {
-                if (!row.course) {
-                    // TODO: handle the course section headers
-                    return <TableSubheading key={row.element.innerText + i.toString()} row={row} />;
-                }
-                return (
-                    <TableRow
-                        key={row.course.uniqueId}
-                        row={row}
-                        isSelected={row.course.uniqueId === selectedCourse?.uniqueId}
-                        activeSchedule={activeSchedule}
-                        onClick={handleRowButtonClick(row.course)}
-                    />
-                );
-            })}
+            {rows.map(
+                row =>
+                    row.course && (
+                        <TableRow
+                            key={row.course.uniqueId}
+                            row={row}
+                            isSelected={row.course.uniqueId === selectedCourse?.uniqueId}
+                            activeSchedule={activeSchedule}
+                            onClick={handleRowButtonClick(row.course)}
+                        />
+                    )
+            )}
             {selectedCourse && (
                 <CourseCatalogInjectedPopup
                     course={selectedCourse}

--- a/src/views/components/calendar/Calendar/Calendar.module.scss
+++ b/src/views/components/calendar/Calendar/Calendar.module.scss
@@ -1,0 +1,8 @@
+.scrollableSchedules {
+    overflow-y: auto; /* Enables vertical scrolling */
+}
+
+.scrollableLimit {
+    overflow-y: auto; /* Enables vertical scrolling */
+    max-height: 35vh; /* Adjusts based on your needs and testing */
+}

--- a/src/views/components/calendar/Calendar/Calendar.tsx
+++ b/src/views/components/calendar/Calendar/Calendar.tsx
@@ -4,46 +4,82 @@ import CalendarGrid from '@views/components/calendar/CalendarGrid/CalendarGrid';
 import CalendarHeader from '@views/components/calendar/CalendarHeader/CalenderHeader';
 import { CalendarSchedules } from '@views/components/calendar/CalendarSchedules/CalendarSchedules';
 import ImportantLinks from '@views/components/calendar/ImportantLinks';
+import TeamLinks from '@views/components/calendar/TeamLinks';
+import Divider from '@views/components/common/Divider/Divider';
 import CourseCatalogInjectedPopup from '@views/components/injected/CourseCatalogInjectedPopup/CourseCatalogInjectedPopup';
 import { useFlattenedCourseSchedule } from '@views/hooks/useFlattenedCourseSchedule';
-import React, { useRef } from 'react';
-import { ExampleCourse } from 'src/stories/components/PopupCourseBlock.stories';
+import React, { useEffect, useRef, useState } from 'react';
 
+import styles from './Calendar.module.scss';
 /**
  * A reusable chip component that follows the design system of the extension.
  * @returns
  */
 export default function Calendar(): JSX.Element {
-    const calendarRef = useRef(null);
+    const calendarRef = useRef<HTMLDivElement>(null);
     const { courseCells, activeSchedule } = useFlattenedCourseSchedule();
-    const [course, setCourse] = React.useState<Course | null>(null);
+    const [course, setCourse] = useState<Course | null>(null);
+    const [sidebarWidth, setSidebarWidth] = useState('20%');
+    const [scale, setScale] = useState(1);
+
+    useEffect(() => {
+        const adjustLayout = () => {
+            const windowHeight = window.innerHeight;
+            const windowWidth = window.innerWidth;
+
+            const desiredCalendarHeight = 760;
+            const minSidebarWidthPixels = 230;
+
+            const scale = Math.min(1, windowHeight / desiredCalendarHeight);
+
+            const sidebarWidthPixels = Math.max(
+                windowWidth * scale - windowWidth + minSidebarWidthPixels,
+                minSidebarWidthPixels
+            );
+            const newSidebarWidth = `${(sidebarWidthPixels / windowWidth) * 100}%`;
+
+            setScale(scale);
+            setSidebarWidth(newSidebarWidth);
+        };
+
+        adjustLayout();
+
+        window.addEventListener('resize', adjustLayout);
+        return () => window.removeEventListener('resize', adjustLayout);
+    }, []);
+
+    const calendarContainerStyle = {
+        transform: `scale(${scale})`,
+        transformOrigin: 'top left',
+        marginTop: '-20px',
+    };
 
     return (
-        <div className='flex flex-col'>
-            <CalendarHeader
-            // TODO: implement props
-            // totalHours={activeSchedule.hours}
-            // scheduleName={activeSchedule.name}
-            // totalCourses={activeSchedule?.courses.length}
-            />
-            <div className='h-screen w-full flex flex-col md:flex-row'>
-                <div className='min-h-[30%] flex flex-col items-start gap-2.5 p-5 pl-7'>
-                    <div className='min-h-[30%]'>
+        <div className='h-screen flex flex-col' style={{ width: 'calc(100% - 1rem)' }}>
+            <div className='pl-5'>
+                <CalendarHeader />
+            </div>
+            <div className={`flex flex-grow flex-row overflow-hidden pl-4 ${styles.scrollableSchedules}`}>
+                <div className='sidebar-style' style={{ width: sidebarWidth, padding: '10px 15px 5px 5px' }}>
+                    <div className={`mb-4 ${styles.scrollableLimit}`}>
                         <CalendarSchedules />
                     </div>
-                    <ImportantLinks />
+                    <Divider orientation='horizontal' size='100%' />
+                    <div className='mt-4'>
+                        <ImportantLinks />
+                    </div>
+                    <Divider orientation='horizontal' size='100%' />
+                    <div className='mt-4'>
+                        <TeamLinks />
+                    </div>
                 </div>
-                <div className='flex flex-grow flex-col gap-4 overflow-hidden pr-12'>
-                    <div ref={calendarRef} className='flex-grow overflow-auto'>
+                <div className='flex flex-grow flex-col' style={calendarContainerStyle} ref={calendarRef}>
+                    <div className='flex-grow overflow-auto'>
                         <CalendarGrid courseCells={courseCells} setCourse={setCourse} />
                     </div>
-                    <div>
-                        <CalendarBottomBar calendarRef={calendarRef} />
-                    </div>
+                    <CalendarBottomBar calendarRef={calendarRef} />
                 </div>
             </div>
-            {/* TODO: Doesn't work when exampleCourse is replaced with an actual course through setCourse.
-                Check CalendarGrid.tsx and AccountForCourseConflicts for an example */}
             {course ? (
                 <CourseCatalogInjectedPopup
                     course={course}

--- a/src/views/components/calendar/CalendarGrid/CalendarGrid.tsx
+++ b/src/views/components/calendar/CalendarGrid/CalendarGrid.tsx
@@ -4,7 +4,7 @@ import { getCourseColors } from '@shared/util/colors';
 import CalendarCourseCell from '@views/components/calendar/CalendarCourseCell/CalendarCourseCell';
 import CalendarCell from '@views/components/calendar/CalendarGridCell/CalendarGridCell';
 import type { CalendarGridCourse } from '@views/hooks/useFlattenedCourseSchedule';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import styles from './CalendarGrid.module.scss';
 
@@ -26,12 +26,10 @@ export default function CalendarGrid({
     saturdayClass,
     setCourse,
 }: React.PropsWithChildren<Props>): JSX.Element {
-    //  const [grid, setGrid] = useState([]);
-    // const calendarRef = useRef(null); // Create a ref for the calendar grid
-    const grid = [];
+    const [grid, setGrid] = useState([]);
 
-    // Run once to create the grid on initial render
     useEffect(() => {
+        const newGrid = [];
         for (let i = 0; i < 13; i++) {
             const row = [];
             let hour = hoursOfDay[i];
@@ -53,9 +51,10 @@ export default function CalendarGrid({
                 };
                 row.push(<CalendarCell key={k} styleProp={styleProp} />);
             }
-            grid.push(row);
+            newGrid.push(row);
         }
-    });
+        setGrid(newGrid);
+    }, []);
 
     return (
         <div className={styles.calendarGrid}>

--- a/src/views/components/calendar/CalendarHeader/CalenderHeader.tsx
+++ b/src/views/components/calendar/CalendarHeader/CalenderHeader.tsx
@@ -28,7 +28,7 @@ const handleOpenOptions = async (): Promise<void> => {
  */
 export default function CalendarHeader(): JSX.Element {
     return (
-        <div className='min-h-79px min-w-672px w-full flex px-0 py-15'>
+        <div className='min-h-79px min-w-672px w-full flex px-0 py-5'>
             <div className='flex flex-row gap-20'>
                 <div className='flex gap-10'>
                     <div className='flex gap-1'>

--- a/src/views/components/calendar/CalendarSchedules/CalendarSchedules.tsx
+++ b/src/views/components/calendar/CalendarSchedules/CalendarSchedules.tsx
@@ -1,5 +1,4 @@
-import createSchedule from '@pages/background/lib/createSchedule';
-import switchSchedule from '@pages/background/lib/switchSchedule';
+import { background } from '@shared/messages';
 import type { UserSchedule } from '@shared/types/UserSchedule';
 import List from '@views/components/common/List/List';
 import ScheduleListItem from '@views/components/common/ScheduleListItem/ScheduleListItem';
@@ -38,8 +37,9 @@ export function CalendarSchedules({ style, dummySchedules, dummyActiveIndex }: P
 
     const handleKeyDown = event => {
         if (event.code === 'Enter') {
-            createSchedule(newSchedule);
-            setNewSchedule('');
+            background.createSchedule({ scheduleName: newSchedule }).then(() => {
+                setNewSchedule('');
+            });
         }
     };
 
@@ -48,8 +48,9 @@ export function CalendarSchedules({ style, dummySchedules, dummyActiveIndex }: P
     };
 
     const selectItem = (index: number) => {
-        setActiveScheduleIndex(index);
-        switchSchedule(schedules[index].name);
+        background.switchSchedule({ scheduleName: schedules[index].name }).then(() => {
+            setActiveScheduleIndex(index);
+        });
     };
 
     const scheduleComponents = schedules.map((schedule, index) => (

--- a/src/views/components/calendar/TeamLinks.tsx
+++ b/src/views/components/calendar/TeamLinks.tsx
@@ -1,0 +1,50 @@
+import Text from '@views/components/common/Text/Text';
+import clsx from 'clsx';
+import React from 'react';
+
+import OutwardArrowIcon from '~icons/material-symbols/arrow-outward';
+
+type Props = {
+    className?: string;
+};
+
+/**
+ * The "From The Team" section of the calendar website
+ * @returns
+ */
+export default function TeamLinks({ className }: Props): JSX.Element {
+    return (
+        <article className={clsx(className, 'flex flex-col gap-2')}>
+            <Text variant='h3'>From The Team</Text>
+            <a
+                href='options.html'
+                className='flex items-center gap-0.5 text-ut-burntorange'
+                target='_blank'
+                rel='noreferrer'
+            >
+                <Text variant='p'>Credits – Meet the team!</Text>
+                <OutwardArrowIcon className='h-3 w-3' />
+            </a>
+            {/* TODO: ADD THE LINK HERE */}
+            <a
+                href='application-link'
+                className='flex items-center gap-0.5 text-ut-burntorange'
+                target='_blank'
+                rel='noreferrer'
+            >
+                <Text variant='p'>Apply to Longhorn Developers</Text>
+                <OutwardArrowIcon className='h-3 w-3' />
+            </a>
+            {/* TODO: ADD THE LINK HERE */}
+            <a
+                href='beta_tester-link'
+                className='flex items-center gap-0.5 text-ut-burntorange'
+                target='_blank'
+                rel='noreferrer'
+            >
+                <Text variant='p'>Become a Beta Tester</Text>
+                <OutwardArrowIcon className='h-3 w-3' />
+            </a>
+        </article>
+    );
+}

--- a/src/views/components/common/Prompt/Prompt.tsx
+++ b/src/views/components/common/Prompt/Prompt.tsx
@@ -1,0 +1,65 @@
+import { Dialog, Transition } from '@headlessui/react';
+import type { ReactElement } from 'react';
+import React from 'react';
+
+import type { Button } from '../Button/Button';
+import type Text from '../Text/Text';
+
+/**
+ * Props for the PromptDialog component.
+ */
+export interface PromptDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+    title: ReactElement<typeof Text>;
+    content: ReactElement<typeof Text>;
+    children?: ReactElement<typeof Button>[];
+}
+
+/**
+ * A reusable dialog component that can be used to display a prompt to the user.
+ * @param {PromptDialogProps} props.isOpen - Whether the dialog is open or not.
+ * @param {Function} props.onClose - A function to call when the user exits the dialog.
+ * @param {React.ReactElement<typeof Text>} props.title - The title of the dialog.
+ * @param {React.ReactElement<typeof Text>} props.content - The content of the dialog.
+ * @param {React.ReactElement<typeof Button>[]} props.children - The buttons to display in the dialog.
+ */
+function PromptDialog({ isOpen, onClose, title, content, children }: PromptDialogProps) {
+    return (
+        <Transition appear show={isOpen} as={React.Fragment}>
+            <Dialog as='div' onClose={onClose} className='relative z-50'>
+                <Transition.Child
+                    as={React.Fragment}
+                    enter='ease-out duration-200'
+                    enterFrom='opacity-0'
+                    enterTo='opacity-100'
+                    leave='ease-in duration-200'
+                    leaveFrom='opacity-100'
+                    leaveTo='opacity-0'
+                >
+                    <div className='fixed inset-0 bg-black bg-opacity-50' aria-hidden='true' />
+                </Transition.Child>
+
+                <Transition.Child
+                    as={React.Fragment}
+                    enter='ease-out duration-200'
+                    enterFrom='opacity-0 scale-95'
+                    enterTo='opacity-100 scale-100'
+                    leave='ease-in duration-200'
+                    leaveFrom='opacity-100 scale-100'
+                    leaveTo='opacity-0 scale-95'
+                >
+                    <div className='fixed inset-0 w-screen flex items-center justify-center'>
+                        <Dialog.Panel className='h-[200] w-[431px] flex flex-col rounded bg-white p-6'>
+                            <Dialog.Title className='mb-[10px]'>{title}</Dialog.Title>
+                            <Dialog.Description className='mb-[13px]'>{content}</Dialog.Description>
+                            <div className='flex items-center justify-end gap-2'>{children}</div>
+                        </Dialog.Panel>
+                    </div>
+                </Transition.Child>
+            </Dialog>
+        </Transition>
+    );
+}
+
+export default PromptDialog;

--- a/src/views/components/injected/TableRow/TableRow.module.scss
+++ b/src/views/components/injected/TableRow/TableRow.module.scss
@@ -72,16 +72,17 @@
 }
 
 .inActiveSchedule {
-    * {
+    > *:not(td:last-child) {
         color: colors.$turtle_pond !important;
         font-weight: bold !important;
     }
 }
 
-.isConflict {
-    * {
-        color: colors.$speedway_brick !important;
-        font-weight: normal !important;
-        text-decoration: line-through !important;
+// for the edge case where they have conflicting classes in their schedule
+.isConflict:not(.inActiveSchedule) {
+    > *:not(td:last-child) {
+        color: colors.$speedway_brick;
+        font-weight: normal;
+        text-decoration: line-through;
     }
 }

--- a/src/views/components/injected/TableRow/TableRow.tsx
+++ b/src/views/components/injected/TableRow/TableRow.tsx
@@ -1,11 +1,10 @@
 import type { Course, ScrapedRow } from '@shared/types/Course';
 import type { UserSchedule } from '@shared/types/UserSchedule';
-import { Button } from '@views/components/common/Button/Button';
 import ConflictsWithWarning from '@views/components/common/ConflictsWithWarning/ConflictsWithWarning';
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
-import AddIcon from '~icons/material-symbols/add-circle';
+import RowIcon from '~icons/material-symbols/bar-chart-rounded';
 
 import styles from './TableRow.module.scss';
 
@@ -30,8 +29,9 @@ export default function TableRow({ row, isSelected, activeSchedule, onClick }: P
 
     useEffect(() => {
         element.classList.add(styles.row);
+        element.classList.add('group');
         const portalContainer = document.createElement('td');
-        portalContainer.style.textAlign = 'right';
+        // portalContainer.style.textAlign = 'right';
         const lastTableCell = element.querySelector('td:last-child');
         lastTableCell!.after(portalContainer);
         setContainer(portalContainer);
@@ -85,16 +85,20 @@ export default function TableRow({ row, isSelected, activeSchedule, onClick }: P
     }
 
     return ReactDOM.createPortal(
-        <>
-            <Button
-                icon={AddIcon}
-                className={styles.rowButton}
-                color='ut-burntorange'
+        <div className='relative'>
+            <button
+                className='bg-ut-burntorange w-6 h-6 items-center justify-center color-white! flex m1 rounded'
                 onClick={onClick}
-                variant='single'
-            />
-            {conflicts.length > 0 && <ConflictsWithWarning className={styles.conflictTooltip} conflicts={conflicts} />}
-        </>,
+            >
+                <RowIcon color='ut-white' />
+            </button>
+            {conflicts.length > 0 && (
+                <ConflictsWithWarning
+                    className='group-hover:visible invisible text-white absolute left-13 top--3'
+                    conflicts={conflicts}
+                />
+            )}
+        </div>,
         container
     );
 }

--- a/src/views/components/injected/TableRow/TableRow.tsx
+++ b/src/views/components/injected/TableRow/TableRow.tsx
@@ -87,14 +87,14 @@ export default function TableRow({ row, isSelected, activeSchedule, onClick }: P
     return ReactDOM.createPortal(
         <div className='relative'>
             <button
-                className='bg-ut-burntorange w-6 h-6 items-center justify-center color-white! flex m1 rounded'
+                className='m1 h-6 w-6 flex items-center justify-center rounded bg-ut-burntorange color-white!'
                 onClick={onClick}
             >
                 <RowIcon color='ut-white' />
             </button>
             {conflicts.length > 0 && (
                 <ConflictsWithWarning
-                    className='group-hover:visible invisible text-white absolute left-13 top--3'
+                    className='invisible absolute left-13 top--3 text-white group-hover:visible'
                     conflicts={conflicts}
                 />
             )}

--- a/src/views/lib/CourseCatalogScraper.ts
+++ b/src/views/lib/CourseCatalogScraper.ts
@@ -92,6 +92,7 @@ export class CourseCatalogScraper {
                 instructors: this.getInstructors(row) as Instructor[],
                 description: this.getDescription(document),
                 semester: this.getSemester(),
+                scrapedAt: Date.now(),
             });
             courses.push({
                 element: row,


### PR DESCRIPTION
Added functionality for:
- Calendar schedules plus button
- Renaming schedules (backend wise)
- Duplicating schedules, along with duplicateSchedules lib function
- Deleting schedules (backend wise)
- Selecting the active schedule index now works. I put the responsibility of handling this logic on individual schedule list items rather than the calendar schedules component.

Known issues:
- Deleting schedules will not remove them from the schedules list component (Sahm mentioned this may be a problem with the list component)
- Same problem as above but with renaming: dragging a renamed schedule will reset its name to what it was before renaming
- Clipping issues with the vertical dots menu when nearing the bottom of the schedules list. I tried out a portal but it would put all vertical dot menus in the same position no matter which one I clicked on the schedules list.