### PR TITLE
feat: abhinavchadaga/reusable-popup-prompt

### DIFF
--- a/src/stories/components/Prompt.stories.tsx
+++ b/src/stories/components/Prompt.stories.tsx
@@ -1,9 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Button } from '@views/components/common/Button/Button';
+import type { PromptDialogProps } from '@views/components/common/Prompt/Prompt';
 import PromptDialog from '@views/components/common/Prompt/Prompt';
+import Text from '@views/components/common/Text/Text';
 import React from 'react';
 
-const meta = {
+const meta: Meta<typeof PromptDialog> = {
     title: 'Components/Common/Prompt',
     component: PromptDialog,
     parameters: {
@@ -12,26 +14,43 @@ const meta = {
     tags: ['autodocs'],
     argTypes: {
         isOpen: { control: 'boolean' },
-        title: { control: 'text' },
-        content: { control: 'text' },
+        title: { control: 'object' },
+        content: { control: 'object' },
         children: { control: 'object' },
     },
-} satisfies Meta<typeof PromptDialog>;
+};
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+// Define a new component for use in the story to comply with React's rules of hooks
+const PromptDialogWithButton = (args: PromptDialogProps) => {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const handleOpen = () => setIsOpen(true);
+    const handleClose = () => setIsOpen(false);
 
-export const Default: Story = {
+    return (
+        <div className='h-screen w-screen flex items-center justify-center'>
+            <Button variant='filled' color='ut-burntorange' onClick={handleOpen}>
+                Open Prompt
+            </Button>
+            <PromptDialog {...args} isOpen={isOpen} onClose={handleClose} />
+        </div>
+    );
+};
+
+export const Default: StoryObj<PromptDialogProps> = {
+    render: args => <PromptDialogWithButton {...args} />, // Use the new component here
     args: {
-        isOpen: true,
-        onClose: () => {},
-        title: 'Are you sure?',
-        content: 'This will delete all of your courses and schedules. Are you sure you want to continue?',
+        title: <Text variant='h2'>Are you sure?</Text>,
+        content: (
+            <Text variant='p'>
+                Deleting Main Schedule is permanent and will remove all added courses and schedules.
+            </Text>
+        ),
         children: [
-            <Button key='yes' variant='filled' color='ut-burntorange' onClick={() => {}}>
+            <Button key='yes' variant='single' color='ut-burntorange' onClick={() => {}}>
                 Yes
             </Button>,
-            <Button key='no' variant='outline' color='ut-black' onClick={() => {}}>
+            <Button key='no' variant='single' color='ut-black' onClick={() => {}}>
                 No
             </Button>,
         ],

--- a/src/stories/components/Prompt.stories.tsx
+++ b/src/stories/components/Prompt.stories.tsx
@@ -21,24 +21,33 @@ const meta: Meta<typeof PromptDialog> = {
 };
 export default meta;
 
-// Define a new component for use in the story to comply with React's rules of hooks
-const PromptDialogWithButton = (args: PromptDialogProps) => {
+const PromptDialogWithButton = ({ children, ...args }: PromptDialogProps) => {
     const [isOpen, setIsOpen] = React.useState(false);
     const handleOpen = () => setIsOpen(true);
     const handleClose = () => setIsOpen(false);
+    const { title, content } = args;
+
+    const childrenWithHandleClose: React.ReactElement[] = children.map(child => {
+        if (child.type === Button) {
+            return React.cloneElement(child, { onClick: () => handleClose() } as React.HTMLAttributes<HTMLElement>);
+        }
+        return child;
+    });
 
     return (
         <div className='h-screen w-screen flex items-center justify-center'>
             <Button variant='filled' color='ut-burntorange' onClick={handleOpen}>
                 Open Prompt
             </Button>
-            <PromptDialog {...args} isOpen={isOpen} onClose={handleClose} />
+            <PromptDialog {...args} isOpen={isOpen} onClose={handleClose} title={title} content={content}>
+                {childrenWithHandleClose}
+            </PromptDialog>
         </div>
     );
 };
 
-export const Default: StoryObj<PromptDialogProps> = {
-    render: args => <PromptDialogWithButton {...args} />, // Use the new component here
+export const AreYouSure: StoryObj<PromptDialogProps> = {
+    render: args => <PromptDialogWithButton {...args} />,
     args: {
         title: <Text variant='h2'>Are you sure?</Text>,
         content: (
@@ -47,11 +56,49 @@ export const Default: StoryObj<PromptDialogProps> = {
             </Text>
         ),
         children: [
-            <Button key='yes' variant='single' color='ut-burntorange' onClick={() => {}}>
+            <Button key='yes' variant='single' color='ut-burntorange'>
                 Yes
             </Button>,
-            <Button key='no' variant='single' color='ut-black' onClick={() => {}}>
+            <Button key='no' variant='single' color='ut-black'>
                 No
+            </Button>,
+        ],
+    },
+};
+
+export const YouHave10ActiveSchedules: StoryObj<PromptDialogProps> = {
+    render: args => <PromptDialogWithButton {...args} />,
+    args: {
+        title: <Text variant='h2'>You have 10 active schedules!</Text>,
+        content: (
+            <Text variant='p'>
+                To encourage organization, please consider removing some unused schedules you may have.
+            </Text>
+        ),
+        children: [
+            <Button key='yes' variant='single' color='ut-black'>
+                I understand
+            </Button>,
+        ],
+    },
+};
+
+export const WelcomeToUTRPV2: StoryObj<PromptDialogProps> = {
+    render: args => <PromptDialogWithButton {...args} />,
+    args: {
+        title: <Text variant='h2'>Welcome to UTRP V2!</Text>,
+        content: (
+            <Text variant='p'>
+                You may have already began planning your Summer or Fall schedule. To migrate your courses into v2.0
+                please select “Migrate,” or start fresh.
+            </Text>
+        ),
+        children: [
+            <Button key='migrate' variant='single' color='ut-black'>
+                Don&apos;t Migrate
+            </Button>,
+            <Button key='start-fresh' variant='single' color='ut-burntorange'>
+                Migrate
             </Button>,
         ],
     },

--- a/src/stories/components/Prompt.stories.tsx
+++ b/src/stories/components/Prompt.stories.tsx
@@ -5,7 +5,7 @@ import PromptDialog from '@views/components/common/Prompt/Prompt';
 import Text from '@views/components/common/Text/Text';
 import React from 'react';
 
-const meta: Meta<typeof PromptDialog> = {
+const meta = {
     title: 'Components/Common/Prompt',
     component: PromptDialog,
     parameters: {
@@ -18,7 +18,7 @@ const meta: Meta<typeof PromptDialog> = {
         content: { control: 'object' },
         children: { control: 'object' },
     },
-};
+} satisfies Meta<typeof PromptDialog>;
 export default meta;
 
 const PromptDialogWithButton = ({ children, ...args }: PromptDialogProps) => {

--- a/src/stories/components/Prompt.stories.tsx
+++ b/src/stories/components/Prompt.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '@views/components/common/Button/Button';
+import PromptDialog from '@views/components/common/Prompt/Prompt';
+import React from 'react';
+
+const meta = {
+    title: 'Components/Common/Prompt',
+    component: PromptDialog,
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        isOpen: { control: 'boolean' },
+        title: { control: 'text' },
+        content: { control: 'text' },
+        children: { control: 'object' },
+    },
+} satisfies Meta<typeof PromptDialog>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        isOpen: true,
+        onClose: () => {},
+        title: 'Are you sure?',
+        content: 'This will delete all of your courses and schedules. Are you sure you want to continue?',
+        children: [
+            <Button key='yes' variant='filled' color='ut-burntorange' onClick={() => {}}>
+                Yes
+            </Button>,
+            <Button key='no' variant='outline' color='ut-black' onClick={() => {}}>
+                No
+            </Button>,
+        ],
+    },
+};

--- a/src/views/components/common/Prompt/Prompt.tsx
+++ b/src/views/components/common/Prompt/Prompt.tsx
@@ -1,30 +1,30 @@
-import { Dialog, Transition } from '@headlessui/react';
+import { Dialog } from '@headlessui/react';
 import React from 'react';
 
 import type { Button } from '../Button/Button';
+import type Text from '../Text/Text';
 
 export interface PromptDialogProps {
     isOpen: boolean;
     onClose: () => void;
-    title: string;
-    content: string;
+    title: React.ReactElement<typeof Text>;
+    content: React.ReactElement<typeof Text>;
     children?: React.ReactElement<typeof Button>[];
 }
 
-const PromptDialog: React.FC<PromptDialogProps> = ({
-    isOpen,
-    onClose,
-    title,
-    content,
-    children,
-}: PromptDialogProps) => (
-    <Dialog open={isOpen} onClose={onClose}>
-        <Dialog.Panel>
-            <Dialog.Title>{title}</Dialog.Title>
-            <Dialog.Description>{content}</Dialog.Description>
-            <div className='flex items-center justify-end gap-2'>{children}</div>
-        </Dialog.Panel>
-    </Dialog>
-);
+function PromptDialog({ isOpen, onClose, title, content, children }: PromptDialogProps) {
+    return (
+        <Dialog open={isOpen} onClose={onClose} className='relative z-50'>
+            <div className='fixed inset-0 bg-black bg-opacity-50' aria-hidden='true' />
+            <div className='fixed inset-0 w-screen flex items-center justify-center'>
+                <Dialog.Panel className='h-[180] w-[409px] flex flex-col rounded bg-white p-6'>
+                    <Dialog.Title className='mb-[10px]'>{title}</Dialog.Title>
+                    <Dialog.Description className='mb-[13px]'>{content}</Dialog.Description>
+                    <div className='flex items-center justify-end gap-2'>{children}</div>
+                </Dialog.Panel>
+            </div>
+        </Dialog>
+    );
+}
 
 export default PromptDialog;

--- a/src/views/components/common/Prompt/Prompt.tsx
+++ b/src/views/components/common/Prompt/Prompt.tsx
@@ -1,4 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react';
+import type { ReactElement } from 'react';
 import React from 'react';
 
 import type { Button } from '../Button/Button';
@@ -10,9 +11,9 @@ import type Text from '../Text/Text';
 export interface PromptDialogProps {
     isOpen: boolean;
     onClose: () => void;
-    title: React.ReactElement<typeof Text>;
-    content: React.ReactElement<typeof Text>;
-    children?: React.ReactElement<typeof Button>[];
+    title: ReactElement<typeof Text>;
+    content: ReactElement<typeof Text>;
+    children?: ReactElement<typeof Button>[];
 }
 
 /**

--- a/src/views/components/common/Prompt/Prompt.tsx
+++ b/src/views/components/common/Prompt/Prompt.tsx
@@ -1,9 +1,12 @@
-import { Dialog } from '@headlessui/react';
+import { Dialog, Transition } from '@headlessui/react';
 import React from 'react';
 
 import type { Button } from '../Button/Button';
 import type Text from '../Text/Text';
 
+/**
+ * Props for the PromptDialog component.
+ */
 export interface PromptDialogProps {
     isOpen: boolean;
     onClose: () => void;
@@ -12,18 +15,49 @@ export interface PromptDialogProps {
     children?: React.ReactElement<typeof Button>[];
 }
 
+/**
+ * A reusable dialog component that can be used to display a prompt to the user.
+ * @param {PromptDialogProps} props.isOpen - Whether the dialog is open or not.
+ * @param {Function} props.onClose - A function to call when the user exits the dialog.
+ * @param {React.ReactElement<typeof Text>} props.title - The title of the dialog.
+ * @param {React.ReactElement<typeof Text>} props.content - The content of the dialog.
+ * @param {React.ReactElement<typeof Button>[]} props.children - The buttons to display in the dialog.
+ */
 function PromptDialog({ isOpen, onClose, title, content, children }: PromptDialogProps) {
     return (
-        <Dialog open={isOpen} onClose={onClose} className='relative z-50'>
-            <div className='fixed inset-0 bg-black bg-opacity-50' aria-hidden='true' />
-            <div className='fixed inset-0 w-screen flex items-center justify-center'>
-                <Dialog.Panel className='h-[180] w-[409px] flex flex-col rounded bg-white p-6'>
-                    <Dialog.Title className='mb-[10px]'>{title}</Dialog.Title>
-                    <Dialog.Description className='mb-[13px]'>{content}</Dialog.Description>
-                    <div className='flex items-center justify-end gap-2'>{children}</div>
-                </Dialog.Panel>
-            </div>
-        </Dialog>
+        <Transition appear show={isOpen} as={React.Fragment}>
+            <Dialog as='div' onClose={onClose} className='relative z-50'>
+                <Transition.Child
+                    as={React.Fragment}
+                    enter='ease-out duration-200'
+                    enterFrom='opacity-0'
+                    enterTo='opacity-100'
+                    leave='ease-in duration-200'
+                    leaveFrom='opacity-100'
+                    leaveTo='opacity-0'
+                >
+                    <div className='fixed inset-0 bg-black bg-opacity-50' aria-hidden='true' />
+                </Transition.Child>
+
+                <Transition.Child
+                    as={React.Fragment}
+                    enter='ease-out duration-200'
+                    enterFrom='opacity-0 scale-95'
+                    enterTo='opacity-100 scale-100'
+                    leave='ease-in duration-200'
+                    leaveFrom='opacity-100 scale-100'
+                    leaveTo='opacity-0 scale-95'
+                >
+                    <div className='fixed inset-0 w-screen flex items-center justify-center'>
+                        <Dialog.Panel className='h-[200] w-[431px] flex flex-col rounded bg-white p-6'>
+                            <Dialog.Title className='mb-[10px]'>{title}</Dialog.Title>
+                            <Dialog.Description className='mb-[13px]'>{content}</Dialog.Description>
+                            <div className='flex items-center justify-end gap-2'>{children}</div>
+                        </Dialog.Panel>
+                    </div>
+                </Transition.Child>
+            </Dialog>
+        </Transition>
     );
 }
 

--- a/src/views/components/common/Prompt/Prompt.tsx
+++ b/src/views/components/common/Prompt/Prompt.tsx
@@ -1,0 +1,30 @@
+import { Dialog, Transition } from '@headlessui/react';
+import React from 'react';
+
+import type { Button } from '../Button/Button';
+
+export interface PromptDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    content: string;
+    children?: React.ReactElement<typeof Button>[];
+}
+
+const PromptDialog: React.FC<PromptDialogProps> = ({
+    isOpen,
+    onClose,
+    title,
+    content,
+    children,
+}: PromptDialogProps) => (
+    <Dialog open={isOpen} onClose={onClose}>
+        <Dialog.Panel>
+            <Dialog.Title>{title}</Dialog.Title>
+            <Dialog.Description>{content}</Dialog.Description>
+            <div className='flex items-center justify-end gap-2'>{children}</div>
+        </Dialog.Panel>
+    </Dialog>
+);
+
+export default PromptDialog;


### PR DESCRIPTION
Reusable popup prompt that takes a title, description, and button children components. Uses headless UI's `Transition` and `Dialog` components for accessibility and interactivity. Handles clicks outside the prompt, escape key, etc.

DEMO
![demo](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/48454518/82b3124f-ac42-4e6a-a4f2-be5dcf2719aa)

