### PR TITLE
feat: added scrapedAt property

### DIFF
--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -1,0 +1,24 @@
+name: Type Check
+
+on: [push, pull_request]
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v3
+              with:
+                  version: 8
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Run tests
+              run: pnpm run check-types

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "prettier:fix": "prettier src --write",
         "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",
         "lint:fix": "eslint src --ext ts,tsx --report-unused-disable-directives --fix",
+        "check-types": "tsc --noEmit",
         "test": "vitest",
         "test:ui": "vitest --ui",
         "coverage": "vitest run --coverage",

--- a/src/shared/types/Course.ts
+++ b/src/shared/types/Course.ts
@@ -73,11 +73,16 @@ export class Course {
     instructionMode: InstructionMode;
     /** Which semester is the course from */
     semester: Semester;
+    /** Unix timestamp of when the course was last scraped */
+    scrapedAt: number;
 
     constructor(course: Serialized<Course>) {
         Object.assign(this, course);
         this.schedule = new CourseSchedule(course.schedule);
         this.instructors = course.instructors.map(i => new Instructor(i));
+        if (!course.scrapedAt) {
+            this.scrapedAt = Date.now();
+        }
     }
 
     /**

--- a/src/stories/components/ConflictsWithWarning.stories.tsx
+++ b/src/stories/components/ConflictsWithWarning.stories.tsx
@@ -44,6 +44,7 @@ export const ExampleCourse: Course = new Course({
     status: Status.WAITLISTED,
     uniqueId: 12345,
     url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20242/12345/',
+    scrapedAt: Date.now(),
 });
 export const ExampleCourse2: Course = new Course({
     courseName: 'PRINCIPLES OF COMPUTER SYSTEMS',
@@ -90,6 +91,7 @@ export const ExampleCourse2: Course = new Course({
     status: Status.WAITLISTED,
     uniqueId: 67890,
     url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20242/12345/',
+    scrapedAt: Date.now(),
 });
 
 const meta = {

--- a/src/stories/components/List.stories.tsx
+++ b/src/stories/components/List.stories.tsx
@@ -25,6 +25,7 @@ const generateCourses = (count: number): Course[] => {
             courseName: 'ELEMS OF COMPTRS/PROGRAMMNG-WB',
             creditHours: 3,
             department: 'C S',
+            scrapedAt: Date.now(),
             description: [
                 'Problem solving and fundamental algorithms for various applications in science, business, and on the World Wide Web, and introductory programming in a modern object-oriented programming language.',
                 'Only one of the following may be counted: Computer Science 303E, 312, 312H. Credit for Computer Science 303E may not be earned after a student has received credit for Computer Science 314, or 314H. May not be counted toward a degree in computer science.',

--- a/src/stories/components/PopupCourseBlock.stories.tsx
+++ b/src/stories/components/PopupCourseBlock.stories.tsx
@@ -17,6 +17,7 @@ export const ExampleCourse: Course = new Course({
     courseName: 'ELEMS OF COMPTRS/PROGRAMMNG-WB',
     creditHours: 3,
     department: 'C S',
+    scrapedAt: Date.now(),
     description: [
         'Problem solving and fundamental algorithms for various applications in science, business, and on the World Wide Web, and introductory programming in a modern object-oriented programming language.',
         'Only one of the following may be counted: Computer Science 303E, 312, 312H. Credit for Computer Science 303E may not be earned after a student has received credit for Computer Science 314, or 314H. May not be counted toward a degree in computer science.',

--- a/src/stories/components/calendar/CalendarBottomBar.stories.tsx
+++ b/src/stories/components/calendar/CalendarBottomBar.stories.tsx
@@ -25,6 +25,7 @@ const exampleGovCourse: Course = new Course({
     schedule: {
         meetings: [],
     },
+    scrapedAt: Date.now(),
     semester: {
         code: '12345',
         season: 'Spring',
@@ -43,6 +44,7 @@ const examplePsyCourse: Course = new Course({
     flags: ['no flag for you >:)'],
     fullName: 'PSY 317L Yada yada',
     instructionMode: 'Online',
+    scrapedAt: Date.now(),
     instructors: [
         new Instructor({
             firstName: 'Bevo',

--- a/src/stories/components/calendar/CalendarCourse.stories.tsx
+++ b/src/stories/components/calendar/CalendarCourse.stories.tsx
@@ -55,6 +55,7 @@ export const Default: Story = {
                 year: 2024,
                 season: 'Spring',
             },
+            scrapedAt: Date.now(),
         }),
         meetingIdx: 0,
         color: 'red',

--- a/src/stories/components/calendar/CalendarSchedules.stories.tsx
+++ b/src/stories/components/calendar/CalendarSchedules.stories.tsx
@@ -61,6 +61,7 @@ const schedules = [
                     year: 2024,
                     season: 'Fall',
                 },
+                scrapedAt: Date.now(),
             }),
         ],
         name: 'Main Schedule',
@@ -98,6 +99,7 @@ const schedules = [
                     year: 2024,
                     season: 'Spring',
                 },
+                scrapedAt: Date.now(),
             }),
             new Course({
                 uniqueId: 123,
@@ -129,6 +131,7 @@ const schedules = [
                     year: 2024,
                     season: 'Fall',
                 },
+                scrapedAt: Date.now(),
             }),
         ],
         name: 'Backup #3',

--- a/src/stories/injected/mocked.ts
+++ b/src/stories/injected/mocked.ts
@@ -17,6 +17,7 @@ export const exampleCourse: Course = new Course({
     flags: ['Quantitative Reasoning'],
     fullName: 'C S 303E ELEMS OF COMPTRS/PROGRAMMNG-WB',
     instructionMode: 'Online',
+    scrapedAt: Date.now(),
     instructors: [
         new Instructor({
             firstName: 'William',
@@ -100,6 +101,7 @@ export const bevoCourse: Course = new Course({
         year: 2024,
         season: 'Spring',
     },
+    scrapedAt: Date.now(),
 });
 
 export const bevoScheule: UserSchedule = new UserSchedule({
@@ -151,6 +153,7 @@ export const MikeScottCS314Course: Course = new Course({
         year: 2024,
         season: 'Spring',
     },
+    scrapedAt: Date.now(),
 });
 
 export const MikeScottCS314Schedule: UserSchedule = new UserSchedule({

--- a/src/views/lib/CourseCatalogScraper.ts
+++ b/src/views/lib/CourseCatalogScraper.ts
@@ -92,6 +92,7 @@ export class CourseCatalogScraper {
                 instructors: this.getInstructors(row) as Instructor[],
                 description: this.getDescription(document),
                 semester: this.getSemester(),
+                scrapedAt: Date.now(),
             });
             courses.push({
                 element: row,


### PR DESCRIPTION
This PR adds a scrapedAt timestamp to our Course class, so now we can keep track of when the course info was last fetched. Handy for keeping things fresh!

I also have set up a new GitHub Action that runs `tsc --noEmit` on PR's, just to catch type errors in CI.