### PR TITLE
feat: async text hiding on Calendar's Bottom Bar when there are no async courses

### DIFF
--- a/src/stories/components/calendar/CalendarBottomBar.stories.tsx
+++ b/src/stories/components/calendar/CalendarBottomBar.stories.tsx
@@ -102,3 +102,14 @@ export const Default: Story = {
         </div>
     ),
 };
+export const Empty: Story = {
+    args: {
+        courses: [],
+        calendarRef: { current: null },
+    },
+    render: props => (
+        <div className='outline-red outline w-292.5!'>
+            <CalendarBottomBar {...props} />
+        </div>
+    ),
+};

--- a/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
+++ b/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
@@ -30,7 +30,7 @@ export default function CalendarBottomBar({ courses, calendarRef }: CalendarBott
         <div className='w-full flex py-1.25 pl-7.5 pr-6.25'>
             <div
                 className={clsx('flex flex-grow items-center gap-3.75 text-nowrap', {
-                    'py-7': !displayCourses,
+                    'py-7.5': !displayCourses,
                 })}
             >
                 {displayCourses && (

--- a/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
+++ b/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
@@ -28,7 +28,9 @@ export default function CalendarBottomBar({ courses, calendarRef }: CalendarBott
 
     return (
         <div className='w-full flex py-1.25'>
-            <div className='flex flex-grow items-center gap-3.75 pl-7.5 pr-2.5 text-nowrap'>
+            <div
+                className={`flex flex-grow items-center gap-3.75 ${displayCourses ? '' : 'py-7'} pl-7.5 pr-2.5 text-nowrap`}
+            >
                 {displayCourses ? (
                     <>
                         <Text variant='h4'>Async. and Other:</Text>

--- a/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
+++ b/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
@@ -3,7 +3,7 @@ import { Button } from '@views/components/common/Button/Button';
 import Divider from '@views/components/common/Divider/Divider';
 import Text from '@views/components/common/Text/Text';
 import clsx from 'clsx';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import CalendarMonthIcon from '~icons/material-symbols/calendar-month';
 import ImageIcon from '~icons/material-symbols/image';
@@ -24,24 +24,34 @@ type CalendarBottomBarProps = {
  * @returns {JSX.Element} The rendered bottom bar component.
  */
 export default function CalendarBottomBar({ courses, calendarRef }: CalendarBottomBarProps): JSX.Element {
+    const [displayCourses, setDisplayCourses] = React.useState(false);
+
+    useEffect(() => {
+        setDisplayCourses(courses && courses.length > 0);
+    }, [courses]);
+
     return (
         <div className='w-full flex py-1.25'>
-            <div className='flex flex-grow items-center gap-3.75 pl-7.5 pr-2.5'>
-                <Text variant='h4'>Async. and Other:</Text>
-                <div className='h-14 inline-flex gap-2.5'>
-                    {courses?.map(({ courseDeptAndInstr, status, colors, className }) => (
-                        <CalendarCourseBlock
-                            courseDeptAndInstr={courseDeptAndInstr}
-                            status={status}
-                            colors={colors}
-                            key={courseDeptAndInstr}
-                            className={clsx(className, 'w-35!')}
-                        />
-                    ))}
-                </div>
+            <div className='flex flex-grow items-center gap-3.75 pl-7.5 pr-2.5 text-nowrap'>
+                {displayCourses ? (
+                    <>
+                        <Text variant='h4'>Async. and Other:</Text>
+                        <div className='h-14 inline-flex gap-2.5'>
+                            {courses.map(({ courseDeptAndInstr, status, colors, className }) => (
+                                <CalendarCourseBlock
+                                    courseDeptAndInstr={courseDeptAndInstr}
+                                    status={status}
+                                    colors={colors}
+                                    key={courseDeptAndInstr}
+                                    className={clsx(className, 'w-35!')}
+                                />
+                            ))}
+                        </div>
+                    </>
+                ) : null}
             </div>
             <div className='flex items-center pl-2.5 pr-7.5'>
-                <Divider orientation='vertical' size='1rem' className='mx-1.25' />
+                {displayCourses ? <Divider orientation='vertical' size='1rem' className='mx-1.25' /> : null}
                 <Button variant='single' color='ut-black' icon={CalendarMonthIcon} onClick={saveAsCal}>
                     Save as .CAL
                 </Button>

--- a/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
+++ b/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
@@ -24,11 +24,7 @@ type CalendarBottomBarProps = {
  * @returns {JSX.Element} The rendered bottom bar component.
  */
 export default function CalendarBottomBar({ courses, calendarRef }: CalendarBottomBarProps): JSX.Element {
-    const [displayCourses, setDisplayCourses] = React.useState(false);
-
-    useEffect(() => {
-        setDisplayCourses(courses && courses.length > 0);
-    }, [courses]);
+    const displayCourses = courses && courses.length > 0;
 
     return (
         <div className='w-full flex py-1.25'>

--- a/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
+++ b/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
@@ -3,7 +3,7 @@ import { Button } from '@views/components/common/Button/Button';
 import Divider from '@views/components/common/Divider/Divider';
 import Text from '@views/components/common/Text/Text';
 import clsx from 'clsx';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import CalendarMonthIcon from '~icons/material-symbols/calendar-month';
 import ImageIcon from '~icons/material-symbols/image';

--- a/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
+++ b/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
@@ -27,33 +27,34 @@ export default function CalendarBottomBar({ courses, calendarRef }: CalendarBott
     const displayCourses = courses && courses.length > 0;
 
     return (
-        <div className='w-full flex py-1.25'>
+        <div className='w-full flex py-1.25 pl-7.5 pr-6.25'>
             <div
-                className={`flex flex-grow items-center gap-3.75 ${displayCourses ? '' : 'py-7'} pl-7.5 pr-2.5 text-nowrap`}
+                className={clsx('flex flex-grow items-center gap-3.75 text-nowrap', {
+                    'py-7': !displayCourses,
+                })}
             >
-                {displayCourses ? (
+                {displayCourses && (
                     <>
-                        <Text variant='h4'>Async. and Other:</Text>
-                        <div className='h-14 inline-flex gap-2.5'>
+                        <Text variant='h4'>Other Classes:</Text>
+                        <div className='inline-flex gap-2.5'>
                             {courses.map(({ courseDeptAndInstr, status, colors, className }) => (
                                 <CalendarCourseBlock
                                     courseDeptAndInstr={courseDeptAndInstr}
                                     status={status}
                                     colors={colors}
                                     key={courseDeptAndInstr}
-                                    className={clsx(className, 'w-35!')}
+                                    className={clsx(className, 'w-35! h-15!')}
                                 />
                             ))}
                         </div>
                     </>
-                ) : null}
+                )}
             </div>
-            <div className='flex items-center pl-2.5 pr-7.5'>
-                {displayCourses ? <Divider orientation='vertical' size='1rem' className='mx-1.25' /> : null}
+            <div className='flex items-center'>
+                {displayCourses && <Divider orientation='vertical' size='1rem' className='mx-1.25' />}
                 <Button variant='single' color='ut-black' icon={CalendarMonthIcon} onClick={saveAsCal}>
                     Save as .CAL
                 </Button>
-                <Divider orientation='vertical' size='1rem' className='mx-1.25' />
                 <Button variant='single' color='ut-black' icon={ImageIcon} onClick={() => saveCalAsPng(calendarRef)}>
                     Save as .PNG
                 </Button>

--- a/src/views/components/calendar/CalendarCourseCell/CalendarCourseCell.tsx
+++ b/src/views/components/calendar/CalendarCourseCell/CalendarCourseCell.tsx
@@ -56,30 +56,27 @@ export default function CalendarCourseCell({
 
     return (
         <div
-            className={clsx(
-                'h-full w-full flex justify-center rounded p-2 overflow-x-hidden cursor-default hover:cursor-pointer',
-                fontColor,
-                className
-            )}
+            className={clsx('h-full w-full flex justify-center rounded p-2 cursor-pointer', fontColor, className)}
             style={{
                 backgroundColor: colors.primaryColor,
             }}
             onClick={onClick}
         >
-            <div className='flex flex-1 flex-col gap-1 overflow-x-hidden'>
+            <div
+                className={clsx('flex flex-1 flex-col gap-0.25 overflow-hidden max-h-full', {
+                    'self-center': !timeAndLocation,
+                })}
+            >
                 <Text
                     variant='h1-course'
-                    className={clsx('-my-0.8 leading-tight', {
-                        truncate: timeAndLocation,
+                    className={clsx('leading-tight truncate', {
+                        '-my-0.8': timeAndLocation,
+                        'text-wrap': !timeAndLocation,
                     })}
                 >
                     {courseDeptAndInstr}
                 </Text>
-                {timeAndLocation && (
-                    <Text variant='h3-course' className='-mb-0.5'>
-                        {timeAndLocation}
-                    </Text>
-                )}
+                {timeAndLocation && <Text variant='h3-course'>{timeAndLocation}</Text>}
             </div>
             {rightIcon && (
                 <div


### PR DESCRIPTION
- feat: calendar bottom bar will not appear when the passed in courses is either undefined or has a length of 0.
- also added an "Empty" story in CalendarBottomBar's storybook to show off the changes