### PR TITLE
feat: fix save as button dividers

### DIFF
--- a/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
+++ b/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
@@ -51,10 +51,11 @@ export default function CalendarBottomBar({ courses, calendarRef }: CalendarBott
                 )}
             </div>
             <div className='flex items-center'>
-                {displayCourses && <Divider orientation='vertical' size='1rem' className='mx-1.25' />}
+                <Divider orientation='vertical' size='1rem' className='mx-1.25' />
                 <Button variant='single' color='ut-black' icon={CalendarMonthIcon} onClick={saveAsCal}>
                     Save as .CAL
                 </Button>
+                <Divider orientation='vertical' size='1rem' className='mx-1.25' />
                 <Button variant='single' color='ut-black' icon={ImageIcon} onClick={() => saveCalAsPng(calendarRef)}>
                     Save as .PNG
                 </Button>

--- a/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
+++ b/src/views/components/calendar/CalendarBottomBar/CalendarBottomBar.tsx
@@ -51,7 +51,7 @@ export default function CalendarBottomBar({ courses, calendarRef }: CalendarBott
                 )}
             </div>
             <div className='flex items-center'>
-                <Divider orientation='vertical' size='1rem' className='mx-1.25' />
+                {displayCourses && <Divider orientation='vertical' size='1rem' className='mx-1.25' />}
                 <Button variant='single' color='ut-black' icon={CalendarMonthIcon} onClick={saveAsCal}>
                     Save as .CAL
                 </Button>


### PR DESCRIPTION
before (no async classes): 
<img width="351" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/3775cfd5-8d5d-4d4b-8887-83face44d7a6">

before (1 or more async classes)
(imagine on vertical line on the left lol)

after: 
<img width="390" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/012ed9b8-1734-4eec-9110-918ab358422e">

discussion, read down from here: https://discord.com/channels/743636346727301172/743636347167834143/1217566097319137331