### PR TITLE
fix: correct parsing of noon

### DIFF
--- a/src/shared/types/CourseSchedule.ts
+++ b/src/shared/types/CourseSchedule.ts
@@ -46,13 +46,12 @@ export class CourseSchedule {
                 .replaceAll('.', '')
                 .split('-')
                 .map(time => {
-                    const [hour, rest] = time.split(':');
-                    const [minute, ampm] = rest.split(' ');
+                    const [rawHour, rest] = time.split(':');
+                    const [rawMinute, ampm] = rest.split(' ');
+                    const hour = (rawHour === '12' ? 0 : Number(rawHour)) + (ampm === 'pm' ? 12 : 0);
+                    const minute = Number(rawMinute);
 
-                    if (ampm === 'pm') {
-                        return Number(hour) * 60 + Number(minute) + 12 * 60;
-                    }
-                    return Number(hour) * 60 + Number(minute);
+                    return hour * 60 + minute;
                 });
 
             const location = locLine.split(' ').filter(Boolean);


### PR DESCRIPTION
before: classes start/ending at noon (or anything 12:xx am/pm) mess up their start/end time, which can also mess up how conflicts are handled

(see the first instance of "endTime", should be 12 * 60 === 720, but an extra 12 hours is added)

![image](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/c0b10899-3817-45d5-9709-752a60309cda)

(this shouldn't be conflicting with a 10am-12pm class)

![image](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/640b6ef4-ebc5-474c-b2e3-c81fb174a6df)


after: corrected

![image](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/271fe4b9-688a-47e0-b9f7-ab4b76425af9)

<img width="1090" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/0cd12868-4d50-4672-b4ea-8111498cbade">

