### PR TITLE
chore: ignore storybook build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ sketch
 
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 package-lock.json
+storybook-static

--- a/.gitignore
+++ b/.gitignore
@@ -209,4 +209,4 @@ sketch
 
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 package-lock.json
-storybook-static
+storybook-static/


### PR DESCRIPTION
Running `pnpm build-storybook` makes a folder called storybook-static, it shouldn't ever be committed