### PR TITLE
feat: pad unique ids to 5 digits

### DIFF
--- a/src/views/components/common/PopupCourseBlock/PopupCourseBlock.tsx
+++ b/src/views/components/common/PopupCourseBlock/PopupCourseBlock.tsx
@@ -32,6 +32,7 @@ export default function PopupCourseBlock({
 }: PopupCourseBlockProps): JSX.Element {
     // whiteText based on secondaryColor
     const fontColor = pickFontColor(colors.primaryColor);
+    const formattedUniqueId = course.uniqueId.toString().padStart(5, '0');
 
     return (
         <div
@@ -50,7 +51,7 @@ export default function PopupCourseBlock({
                 <DragIndicatorIcon className='h-6 w-6 text-white' />
             </div>
             <Text className={clsx('flex-1 py-3.5 truncate', fontColor)} variant='h1-course'>
-                <span className='px-0.5 font-450'>{course.uniqueId}</span> {course.department} {course.number} &ndash;{' '}
+                <span className='px-0.5 font-450'>{formattedUniqueId}</span> {course.department} {course.number} &ndash;{' '}
                 {course.instructors.length === 0 ? 'Unknown' : course.instructors.map(v => v.lastName)}
             </Text>
             {course.status !== Status.OPEN && (

--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -58,6 +58,7 @@ const capitalizeString = (str: string) => str.charAt(0).toUpperCase() + str.slic
 export default function HeadingAndActions({ course, activeSchedule, onClose }: HeadingAndActionProps): JSX.Element {
     const { courseName, department, number: courseNumber, uniqueId, instructors, flags, schedule } = course;
     const courseAdded = activeSchedule.courses.some(ourCourse => ourCourse.uniqueId === uniqueId);
+    const formattedUniqueId = uniqueId.toString().padStart(5, '0');
 
     const getInstructorFullName = (instructor: Instructor) => {
         const { firstName, lastName } = instructor;
@@ -68,7 +69,7 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
     const instructorString = instructors.map(getInstructorFullName).join(', ');
 
     const handleCopy = () => {
-        navigator.clipboard.writeText(uniqueId.toString());
+        navigator.clipboard.writeText(formattedUniqueId);
     };
 
     const handleOpenRateMyProf = async () => {
@@ -118,7 +119,7 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
                         ({department} {courseNumber})
                     </Text>
                     <Button color='ut-burntorange' variant='single' icon={Copy} onClick={handleCopy}>
-                        {uniqueId}
+                        {formattedUniqueId}
                     </Button>
                     <button className='bg-transparent p-0 btn' onClick={onClose}>
                         <CloseIcon className='h-7 w-7' />


### PR DESCRIPTION
Pads unique numbers to 5 digits, both when displaying and when copying

Unique's need to be 5 digits, searching by the 4-digit version yields the error "Unique number needs to be 5 digits."

Before:
<img width="790" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/eafb95d6-212e-4805-935f-32df1af1bc1d">
<img width="342" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/0c8c41d2-5093-47d9-9df1-2f3d74843c73">

After:
<img width="793" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/0b5705ae-aa75-4ae3-9ede-aa7a33d237b0">
<img width="354" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/cd1a6f26-a22f-4a58-906b-4028928bcc57">