### PR TITLE
feat: Course Flag Tooltips

### DIFF
--- a/src/views/components/common/Chip/Chip.tsx
+++ b/src/views/components/common/Chip/Chip.tsx
@@ -16,23 +16,24 @@ export const flagMap = {
 
 interface Props {
     label: Flag;
+    tooltip: String;
 }
 
 /**
  * A reusable chip component that follows the design system of the extension.
  * @returns
  */
-export function Chip({ label }: React.PropsWithChildren<Props>): JSX.Element {
+
+export function Chip({ label }: Props): JSX.Element {
     return (
-        <Text
-            as='div'
-            variant='h4'
-            className='min-w-5 inline-flex items-center justify-center gap-2.5 rounded-lg px-1.5 py-0.5'
-            style={{
-                backgroundColor: '#FFD600',
-            }}
-        >
-            {label}
-        </Text>
+        <div className='relative inline-block'>
+            <span className='rounded-lg bg-yellow-500 px-2 py-1 text-white text-sm font-medium cursor-pointer'>
+                {label}
+            </span>
+            {/* Tooltip */}
+            <span className='absolute bg-gray-700 text-white text-xs px-2 py-1 rounded opacity-0 pointer-events-none bottom-full left-1/2 transform -translate-x-1/2 transition-opacity duration-300 ease-in-out group-hover:opacity-100'>
+                {label}
+            </span>
+        </div>
     );
 }

--- a/src/views/components/common/Chip/Chip.tsx
+++ b/src/views/components/common/Chip/Chip.tsx
@@ -16,24 +16,24 @@ export const flagMap = {
 
 interface Props {
     label: Flag;
-    tooltip: String;
 }
 
 /**
  * A reusable chip component that follows the design system of the extension.
  * @returns
  */
-
-export function Chip({ label }: Props): JSX.Element {
+export function Chip({ label }: React.PropsWithChildren<Props>): JSX.Element {
     return (
-        <div className='relative inline-block'>
-            <span className='rounded-lg bg-yellow-500 px-2 py-1 text-white text-sm font-medium cursor-pointer'>
-                {label}
-            </span>
-            {/* Tooltip */}
-            <span className='absolute bg-gray-700 text-white text-xs px-2 py-1 rounded opacity-0 pointer-events-none bottom-full left-1/2 transform -translate-x-1/2 transition-opacity duration-300 ease-in-out group-hover:opacity-100'>
-                {label}
-            </span>
-        </div>
+        <Text
+            as='div'
+            variant='h4'
+            className='min-w-5 inline-flex items-center justify-center gap-2.5 rounded-lg px-1.5 py-0.5'
+            style={{
+                backgroundColor: '#FFD600',
+            }}
+            title={Object.keys(flagMap).find(key => flagMap[key] === label) || ''}
+        >
+            {label}
+        </Text>
     );
 }

--- a/src/views/components/common/Chip/Chip.tsx
+++ b/src/views/components/common/Chip/Chip.tsx
@@ -31,7 +31,7 @@ export function Chip({ label }: React.PropsWithChildren<Props>): JSX.Element {
             style={{
                 backgroundColor: '#FFD600',
             }}
-            title={Object.keys(flagMap).find(key => flagMap[key] === label) || ''}
+            title={Object.keys(flagMap).find(key => flagMap[key] === label)}
         >
             {label}
         </Text>

--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -136,7 +136,7 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
                     )}
                     <div className='flex gap-1'>
                         {flags.map(flag => (
-                            <Chip key={flagMap[flag]} hover:label={flagMap[flag]} />
+                            <Chip key={flagMap[flag]} label={flagMap[flag]} title='Test' />
                         ))}
                     </div>
                 </div>

--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -136,7 +136,7 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
                     )}
                     <div className='flex gap-1'>
                         {flags.map(flag => (
-                            <Chip key={flagMap[flag]} label={flagMap[flag]} />
+                            <Chip key={flagMap[flag]} hover:label={flagMap[flag]} />
                         ))}
                     </div>
                 </div>

--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -136,7 +136,7 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
                     )}
                     <div className='flex gap-1'>
                         {flags.map(flag => (
-                            <Chip key={flagMap[flag]} label={flagMap[flag]} title='Test' />
+                            <Chip key={flagMap[flag]} label={flagMap[flag]} />
                         ))}
                     </div>
                 </div>


### PR DESCRIPTION
Added tooltips for course flags that show when you hover on the flag Chip! 
![Components _ Common _ Chip - Default ⋅ Storybook and 12 more pages - Personal - Microsoft​ Edge 3_18_2024 12_11_36 AM](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/53978637/e42acf42-22dc-4fe8-a41e-64af972f3940)

I can't actually get any images because tooltips don't get captured in images on Windows, but supposedly if you hovered over this "QR" it would say "Quantitative Reasoning", which is really convenient and doesn't cover up anything. 

I stumbled upon this when I was playtesting our build by pretending to be a normal student, and when I was hovering over flags to see what their full name was, nothing would pop up; so here we go