### PR TITLE
fix: async course display size

### DIFF
--- a/src/views/components/calendar/CalendarCourseCell/CalendarCourseCell.tsx
+++ b/src/views/components/calendar/CalendarCourseCell/CalendarCourseCell.tsx
@@ -57,7 +57,11 @@ export default function CalendarCourseCell({
     return (
         <div
             className={clsx(
-                'h-full min-w-full w-0 flex justify-center rounded p-2 cursor-pointer',
+                'h-full w-0 flex justify-center rounded p-2 cursor-pointer screenshot:p-1.5',
+                {
+                    'min-w-full': timeAndLocation,
+                    'w-full': !timeAndLocation,
+                },
                 fontColor,
                 className
             )}


### PR DESCRIPTION
before (ew, so wide):
<img width="796" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/89827ce8-b4f3-4498-a697-39922f653b71">

after:
<img width="812" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/33407a24-2526-4a16-afce-d856539f3a50">

I narrowed it down to a one-line change in #172: 
<img width="1135" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/2c803956-1a62-41b2-a741-4f3be1f4d08f">
