### PR TITLE
fix: prompt font family

### DIFF
--- a/src/views/components/common/Prompt/Prompt.tsx
+++ b/src/views/components/common/Prompt/Prompt.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react';
 import React from 'react';
 
 import type { Button } from '../Button/Button';
+import ExtensionRoot from '../ExtensionRoot/ExtensionRoot';
 import type Text from '../Text/Text';
 
 /**
@@ -27,36 +28,38 @@ export interface PromptDialogProps {
 function PromptDialog({ isOpen, onClose, title, content, children }: PromptDialogProps) {
     return (
         <Transition appear show={isOpen} as={React.Fragment}>
-            <Dialog as='div' onClose={onClose} className='relative z-50 font-sans'>
-                <Transition.Child
-                    as={React.Fragment}
-                    enter='ease-out duration-200'
-                    enterFrom='opacity-0'
-                    enterTo='opacity-100'
-                    leave='ease-in duration-200'
-                    leaveFrom='opacity-100'
-                    leaveTo='opacity-0'
-                >
-                    <div className='fixed inset-0 bg-black bg-opacity-50' aria-hidden='true' />
-                </Transition.Child>
+            <Dialog as='div' onClose={onClose} className='relative z-50'>
+                <ExtensionRoot>
+                    <Transition.Child
+                        as={React.Fragment}
+                        enter='ease-out duration-200'
+                        enterFrom='opacity-0'
+                        enterTo='opacity-100'
+                        leave='ease-in duration-200'
+                        leaveFrom='opacity-100'
+                        leaveTo='opacity-0'
+                    >
+                        <div className='fixed inset-0 bg-black bg-opacity-50' aria-hidden='true' />
+                    </Transition.Child>
 
-                <Transition.Child
-                    as={React.Fragment}
-                    enter='ease-out duration-200'
-                    enterFrom='opacity-0 scale-95'
-                    enterTo='opacity-100 scale-100'
-                    leave='ease-in duration-200'
-                    leaveFrom='opacity-100 scale-100'
-                    leaveTo='opacity-0 scale-95'
-                >
-                    <div className='fixed inset-0 w-screen flex items-center justify-center'>
-                        <Dialog.Panel className='h-[200] w-[431px] flex flex-col rounded bg-white p-6'>
-                            <Dialog.Title className='mb-[10px]'>{title}</Dialog.Title>
-                            <Dialog.Description className='mb-[13px]'>{content}</Dialog.Description>
-                            <div className='flex items-center justify-end gap-2'>{children}</div>
-                        </Dialog.Panel>
-                    </div>
-                </Transition.Child>
+                    <Transition.Child
+                        as={React.Fragment}
+                        enter='ease-out duration-200'
+                        enterFrom='opacity-0 scale-95'
+                        enterTo='opacity-100 scale-100'
+                        leave='ease-in duration-200'
+                        leaveFrom='opacity-100 scale-100'
+                        leaveTo='opacity-0 scale-95'
+                    >
+                        <div className='fixed inset-0 w-screen flex items-center justify-center'>
+                            <Dialog.Panel className='h-[200] w-[431px] flex flex-col rounded bg-white p-6'>
+                                <Dialog.Title className='mb-[10px]'>{title}</Dialog.Title>
+                                <Dialog.Description className='mb-[13px]'>{content}</Dialog.Description>
+                                <div className='flex items-center justify-end gap-2'>{children}</div>
+                            </Dialog.Panel>
+                        </div>
+                    </Transition.Child>
+                </ExtensionRoot>
             </Dialog>
         </Transition>
     );

--- a/src/views/components/common/Prompt/Prompt.tsx
+++ b/src/views/components/common/Prompt/Prompt.tsx
@@ -27,7 +27,7 @@ export interface PromptDialogProps {
 function PromptDialog({ isOpen, onClose, title, content, children }: PromptDialogProps) {
     return (
         <Transition appear show={isOpen} as={React.Fragment}>
-            <Dialog as='div' onClose={onClose} className='relative z-50'>
+            <Dialog as='div' onClose={onClose} className='relative z-5 font-sans'>
                 <Transition.Child
                     as={React.Fragment}
                     enter='ease-out duration-200'

--- a/src/views/components/common/Prompt/Prompt.tsx
+++ b/src/views/components/common/Prompt/Prompt.tsx
@@ -27,7 +27,7 @@ export interface PromptDialogProps {
 function PromptDialog({ isOpen, onClose, title, content, children }: PromptDialogProps) {
     return (
         <Transition appear show={isOpen} as={React.Fragment}>
-            <Dialog as='div' onClose={onClose} className='relative z-5 font-sans'>
+            <Dialog as='div' onClose={onClose} className='relative z-50 font-sans'>
                 <Transition.Child
                     as={React.Fragment}
                     enter='ease-out duration-200'


### PR DESCRIPTION
before (yuck 🤮):
![image](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/51280225-8cef-4f97-8656-116f5830b90b)

after (yummy 🤑):
![image](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/b21e48be-3c43-4de1-ade6-fcf965d30619)

what caused this?

the Text component used to have `font-sans` on it, but it was dropped in favor of just having `font-sans` in the ExtensionRoot.

this works for most things, but the Prompt component renders outside of the ExtensionRoot, so its children don't get the effects of `font-sans`, until today.

~~introducing, a one-line change: adding `font-sans` to the Prompt.~~

introducing a three-line change: wrapping the component in ExtensionRoot

this simple change will revolutionize UTRP

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/183)
<!-- Reviewable:end -->
