### PR TITLE
fix: don't crash on cultural diversity flag

### DIFF
--- a/src/views/components/common/Chip.tsx
+++ b/src/views/components/common/Chip.tsx
@@ -9,7 +9,7 @@ export const flagMap = {
     Writing: 'WR',
     'Quantitative Reasoning': 'QR',
     'Global Cultures': 'GC',
-    'Cultural Diversity in the United States': 'CD',
+    'Cultural Diversity': 'CD',
     Ethics: 'E',
     'Independent Inquiry': 'II',
 } as const satisfies Record<string, Flag>;
@@ -31,7 +31,7 @@ export function Chip({ label }: React.PropsWithChildren<Props>): JSX.Element {
             style={{
                 backgroundColor: '#FFD600',
             }}
-            title={Object.entries(flagMap).find(([full, short]) => short === label)![0]}
+            title={Object.entries(flagMap).find(([full, short]) => short === label)?.[0] ?? label}
         >
             {label}
         </Text>


### PR DESCRIPTION
previously, the extension would crash when opening a course that had a cultural diversity flag

example: https://utdirect.utexas.edu/apps/registrar/course_schedule/20249/30395/

Co-authored-by: Som Gupta <78577376+knownotunknown@users.noreply.github.com>

<!-- Reviewable:start -->
- - -
This change is not [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/196)
<!-- Reviewable:end -->
