### PR TITLE
fix: remove course name from the syllabi lookup

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -85,9 +85,13 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
     };
 
     const handleOpenPastSyllabi = async () => {
-        // not specific to professor
-        const url = `https://utdirect.utexas.edu/apps/student/coursedocs/nlogon/?year=&semester=&department=${department}&course_number=${courseNumber}&course_title=&unique=&instructor_first=&instructor_last=&course_type=In+Residence&search=Search`;
-        openNewTab({ url });
+        for (const instructor of instructors) {
+            let { firstName = '', lastName = '' } = instructor;
+            firstName = capitalizeString(firstName);
+            lastName = capitalizeString(lastName);
+            const url = `https://utdirect.utexas.edu/apps/student/coursedocs/nlogon/?year=&semester=&department=${department}&course_number=${courseNumber}&course_title=&unique=&instructor_first=${firstName}&instructor_last=${lastName}&course_type=In+Residence&search=Search`;
+            openNewTab({ url });
+        }
     };
 
     const handleAddOrRemoveCourse = async () => {

--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -86,7 +86,7 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
 
     const handleOpenPastSyllabi = async () => {
         // not specific to professor
-        const url = `https://utdirect.utexas.edu/apps/student/coursedocs/nlogon/?year=&semester=&department=${department}&course_number=${courseNumber}&course_title=${courseName}&unique=&instructor_first=&instructor_last=&course_type=In+Residence&search=Search`;
+        const url = `https://utdirect.utexas.edu/apps/student/coursedocs/nlogon/?year=&semester=&department=${department}&course_number=${courseNumber}&course_title=&unique=&instructor_first=&instructor_last=&course_type=In+Residence&search=Search`;
         openNewTab({ url });
     };
 


### PR DESCRIPTION
Remove the course name and add the instructor first and last name to the lookup. Opens a new tab for each instructor in the list of instructors.

**Single professor**
![single-professor](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/48454518/5d3c5279-7772-4f99-9034-df9a25ee4c44)

**Multiple professors**
![multiple-professors](https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/48454518/a0d5fb03-96ab-4a30-816f-0263419d65a5)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/200)
<!-- Reviewable:end -->
