### PR TITLE
fix: Sum courses for same semester but different unique

### DIFF
--- a/src/views/lib/database/queryDistribution.ts
+++ b/src/views/lib/database/queryDistribution.ts
@@ -118,10 +118,29 @@ export async function querySemesterDistribution(course: Course, semester: Semest
         throw new NoDataError(course);
     }
 
-    let row: Required<CourseSQLRow> = {} as Required<CourseSQLRow>;
-    res.columns.forEach((col, i) => {
-        row[col as keyof CourseSQLRow] = res.values[0]![i]! as never;
-    });
+    const row: Required<CourseSQLRow> = {} as Required<CourseSQLRow>;
+    for (let i = 0; i < res.columns.length; i++) {
+        const col = res.columns[i] as keyof CourseSQLRow;
+        switch (col) {
+            case 'A':
+            case 'A_Minus':
+            case 'B_Plus':
+            case 'B':
+            case 'B_Minus':
+            case 'C_Plus':
+            case 'C':
+            case 'C_Minus':
+            case 'D_Plus':
+            case 'D':
+            case 'D_Minus':
+            case 'F':
+            case 'Other':
+                row[col] = res.values.reduce((acc, cur) => acc + (cur[i] as number), 0) as never;
+                break;
+            default:
+                row[col] = res.columns[i]![0]! as never;
+        }
+    }
 
     return {
         A: row.A,


### PR DESCRIPTION
This was originally part of #191, then wasn't included when it was kinda weirdly manually merged into #163

Anyways, this PR just kinda copies over the logic from the aggregate part so that, when looking at individual semesters, it properly sums all the sections that happened during that semester instead of just the first one.

Before: C S 314 Grades Spring 2023
<img width="740" alt="Screenshot 2024-03-25 at 7 00 55 PM" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/eb2236de-060a-4414-941f-144910d0a6bc">

After: C S 314 Grades Spring 2023 (same thing)
<img width="743" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/ac3bd13b-9e27-4e37-b35c-27fb50b24c0d">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/202)
<!-- Reviewable:end -->
