### PR TITLE
feat: better discord icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@crxjs/vite-plugin": "2.0.0-beta.21",
         "@iconify-json/material-symbols": "^1.1.73",
         "@iconify-json/ri": "^1.1.20",
+        "@iconify-json/bi": "^1.1.23",
         "@storybook/addon-designs": "^7.0.9",
         "@storybook/addon-essentials": "^7.6.17",
         "@storybook/addon-links": "^7.6.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ devDependencies:
   '@crxjs/vite-plugin':
     specifier: 2.0.0-beta.21
     version: 2.0.0-beta.21(patch_hash=xq4uab3o3kbvv4gixvawl2aj5q)
+  '@iconify-json/bi':
+    specifier: ^1.1.23
+    version: 1.1.23
   '@iconify-json/material-symbols':
     specifier: ^1.1.73
     version: 1.1.73
@@ -2313,6 +2316,12 @@ packages:
 
   /@humanwhocodes/object-schema@2.0.2:
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
+    dev: true
+
+  /@iconify-json/bi@1.1.23:
+    resolution: {integrity: sha512-1te+g9ZzI+PU1Lv6Xerd3XPXf4DE6g3TvDL2buIopTAfrauPHyXCHPFQMrzoQVNrVPCpN3rv3vBtJMPyBwJ9IA==}
+    dependencies:
+      '@iconify/types': 2.0.0
     dev: true
 
   /@iconify-json/material-symbols@1.1.73:

--- a/src/views/components/calendar/CalendarFooter.tsx
+++ b/src/views/components/calendar/CalendarFooter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import DiscordIcon from '~icons/ri/discord-line';
+import DiscordIcon from '~icons/bi/discord';
 import GithubIcon from '~icons/ri/github-fill';
 import InstagramIcon from '~icons/ri/instagram-line';
 


### PR DESCRIPTION
old (yuck)

<img width="263" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/3aa25ee6-cbec-4a7b-b075-dc8353c8f6cb">


new (yum)

<img width="264" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/ff7a145e-9029-4275-b861-c6ae875768f6">

why?

<img width="658" alt="image" src="https://github.com/Longhorn-Developers/UT-Registration-Plus/assets/29130894/abc160b2-87ef-4acb-8767-e9825afb15a7">

also, in my professional opinion (and the opinion of my roommate), _none_ of the discord icons that are outlines look right.

---

<!-- Reviewable:start -->
I'm 99% sure this PR is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/205) but it might not be
<!-- Reviewable:end -->
