### PR TITLE
fix: disappearing dialog error message

### DIFF
--- a/src/views/components/common/ScheduleListItem.tsx
+++ b/src/views/components/common/ScheduleListItem.tsx
@@ -30,6 +30,7 @@ export default function ScheduleListItem({ schedule, dragHandleProps, onClick }:
     const [isEditing, setIsEditing] = useState(false);
     const [editorValue, setEditorValue] = useState(schedule.name);
     const [error, setError] = useState<string | undefined>(undefined);
+    const [lastErrorMessage, setLastErrorMessage] = useState<string | undefined>(undefined);
 
     const editorRef = React.useRef<HTMLInputElement>(null);
     useEffect(() => {
@@ -55,7 +56,10 @@ export default function ScheduleListItem({ schedule, dragHandleProps, onClick }:
     };
 
     const onDelete = () => {
-        deleteSchedule(schedule.id).catch(e => setError(e.message));
+        deleteSchedule(schedule.id).catch(e => {
+            setError(e.message);
+            setLastErrorMessage(e.message);
+        });
     };
 
     return (
@@ -68,7 +72,7 @@ export default function ScheduleListItem({ schedule, dragHandleProps, onClick }:
                         Something Went Wrong
                     </Text>
                 }
-                content={<Text variant='p'>{error}</Text>}
+                content={<Text variant='p'>{error || lastErrorMessage}</Text>}
                 // eslint-disable-next-line react/no-children-prop
                 children={[
                     <Button key='yes' variant='filled' color='ut-black' onClick={() => setError(undefined)}>


### PR DESCRIPTION
#252 

Added a new state that keeps track of the last error message so that the message still displays even when `error` state is set to `undefined` on close

https://github.com/user-attachments/assets/471e6bdc-6109-4384-8bf8-85cc47c18731

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/253)
<!-- Reviewable:end -->
