### PR TITLE
fix: doesn't autoload on pages that don't have pages to load

### DIFF
--- a/src/views/components/injected/AutoLoad/AutoLoad.tsx
+++ b/src/views/components/injected/AutoLoad/AutoLoad.tsx
@@ -64,7 +64,7 @@ export default function AutoLoad({ addRows }: Props): JSX.Element | null {
         addRows(scrapedRows);
     }, [addRows, isSinglePage]);
 
-    if (!container || status === AutoLoadStatus.DONE || isSinglePage ) {
+    if (!container || status === AutoLoadStatus.DONE || isSinglePage) {
         return null;
     }
 

--- a/src/views/components/injected/AutoLoad/AutoLoad.tsx
+++ b/src/views/components/injected/AutoLoad/AutoLoad.tsx
@@ -7,6 +7,7 @@ import { SiteSupport } from '@views/lib/getSiteSupport';
 import type { AutoLoadStatusType } from '@views/lib/loadNextCourseCatalogPage';
 import {
     AutoLoadStatus,
+    getNextButton,
     loadNextCourseCatalogPage,
     removePaginationButtons,
 } from '@views/lib/loadNextCourseCatalogPage';
@@ -27,12 +28,17 @@ type Props = {
 export default function AutoLoad({ addRows }: Props): JSX.Element | null {
     const [container, setContainer] = useState<HTMLDivElement | null>(null);
     const [status, setStatus] = useState<AutoLoadStatusType>(AutoLoadStatus.IDLE);
+    const [isSinglePage, setIsSinglePage] = useState(false);
 
     useEffect(() => {
         const portalContainer = document.createElement('div');
         const lastTableCell = document.querySelector('table')!;
         lastTableCell!.after(portalContainer);
         setContainer(portalContainer);
+    }, []);
+
+    useEffect(() => {
+        setIsSinglePage(!getNextButton(document));
     }, []);
 
     useEffect(() => {
@@ -43,6 +49,7 @@ export default function AutoLoad({ addRows }: Props): JSX.Element | null {
 
     // This hook will call the callback when the user scrolls to the bottom of the page.
     useInfiniteScroll(async () => {
+        if (isSinglePage) return;
         // fetch the next page of courses
         const [status, nextRows] = await loadNextCourseCatalogPage();
         setStatus(status);
@@ -55,9 +62,9 @@ export default function AutoLoad({ addRows }: Props): JSX.Element | null {
 
         // add the scraped courses to the current page
         addRows(scrapedRows);
-    }, [addRows]);
+    }, [addRows, isSinglePage]);
 
-    if (!container || status === AutoLoadStatus.DONE) {
+    if (!container || status === AutoLoadStatus.DONE || isSinglePage ) {
         return null;
     }
 

--- a/src/views/lib/loadNextCourseCatalogPage.ts
+++ b/src/views/lib/loadNextCourseCatalogPage.ts
@@ -70,7 +70,7 @@ export async function loadNextCourseCatalogPage(): Promise<[AutoLoadStatusType, 
  * @param doc  the document to get the next button from
  * @returns the next button from the document
  */
-function getNextButton(doc: Document) {
+export function getNextButton(doc: Document) {
     return doc.querySelector<HTMLAnchorElement>(NEXT_PAGE_BUTTON_SELECTOR);
 }
 


### PR DESCRIPTION
TL;DR before we showing autoload even on singular course pages, and pages that didn't even have other pages to go to. This fixes that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/270)
<!-- Reviewable:end -->
