### PR TITLE
fix: disabled [object Object] hover message on dialog popups

### DIFF
--- a/src/views/components/common/Dialog.tsx
+++ b/src/views/components/common/Dialog.tsx
@@ -28,7 +28,7 @@ export type DialogProps = _DialogProps & Omit<TransitionRootProps<typeof HDialog
  * A reusable popup component that can be used to display content on the page
  */
 export default function Dialog(props: PropsWithChildren<DialogProps>): JSX.Element {
-    const { children, className, open, ...rest } = props;
+    const { children, className, open, title, description, ...rest } = props;
 
     return (
         <Transition show={open} as={HDialog} {...rest}>
@@ -60,8 +60,8 @@ export default function Dialog(props: PropsWithChildren<DialogProps>): JSX.Eleme
                                 className
                             )}
                         >
-                            {props.title && <DialogTitle as={Fragment}>{props.title}</DialogTitle>}
-                            {props.description && <Description as={Fragment}>{props.description}</Description>}
+                            {title && <DialogTitle as={Fragment}>{title}</DialogTitle>}
+                            {description && <Description as={Fragment}>{description}</Description>}
                             {children}
                         </DialogPanel>
                     </TransitionChild>

--- a/src/views/components/common/Dialog.tsx
+++ b/src/views/components/common/Dialog.tsx
@@ -15,7 +15,7 @@ import ExtensionRoot from './ExtensionRoot/ExtensionRoot';
 
 export interface _DialogProps {
     className?: string;
-    headline?: JSX.Element;
+    title?: JSX.Element;
     description?: JSX.Element;
 }
 
@@ -60,7 +60,7 @@ export default function Dialog(props: PropsWithChildren<DialogProps>): JSX.Eleme
                                 className
                             )}
                         >
-                            {props.headline && <DialogTitle as={Fragment}>{props.headline}</DialogTitle>}
+                            {props.title && <DialogTitle as={Fragment}>{props.title}</DialogTitle>}
                             {props.description && <Description as={Fragment}>{props.description}</Description>}
                             {children}
                         </DialogPanel>

--- a/src/views/components/common/Dialog.tsx
+++ b/src/views/components/common/Dialog.tsx
@@ -15,7 +15,7 @@ import ExtensionRoot from './ExtensionRoot/ExtensionRoot';
 
 export interface _DialogProps {
     className?: string;
-    title?: JSX.Element;
+    headline?: JSX.Element;
     description?: JSX.Element;
 }
 
@@ -60,7 +60,7 @@ export default function Dialog(props: PropsWithChildren<DialogProps>): JSX.Eleme
                                 className
                             )}
                         >
-                            {props.title && <DialogTitle as={Fragment}>{props.title}</DialogTitle>}
+                            {props.headline && <DialogTitle as={Fragment}>{props.headline}</DialogTitle>}
                             {props.description && <Description as={Fragment}>{props.description}</Description>}
                             {children}
                         </DialogPanel>

--- a/src/views/components/common/DialogProvider/DialogProvider.tsx
+++ b/src/views/components/common/DialogProvider/DialogProvider.tsx
@@ -87,7 +87,7 @@ export default function DialogProvider(props: { children: ReactNode }): JSX.Elem
                 key={id}
                 onClose={handleClose}
                 afterLeave={onLeave}
-                title=<>{infoUnwrapped.title}</>
+                headline=<>{infoUnwrapped.title}</>
                 description=<>{infoUnwrapped.description}</>
                 appear
                 show={show}

--- a/src/views/components/common/DialogProvider/DialogProvider.tsx
+++ b/src/views/components/common/DialogProvider/DialogProvider.tsx
@@ -87,7 +87,7 @@ export default function DialogProvider(props: { children: ReactNode }): JSX.Elem
                 key={id}
                 onClose={handleClose}
                 afterLeave={onLeave}
-                headline=<>{infoUnwrapped.title}</>
+                title=<>{infoUnwrapped.title}</>
                 description=<>{infoUnwrapped.description}</>
                 appear
                 show={show}


### PR DESCRIPTION
- Previously, a [Object object] message would popup when hovering over a button in a DialogProvider component
- Now, no hover message is shown.
~~- Root cause seems to be that rendering a component with an attribute named `title` will display some sort of hover message -> https://github.com/bvaughn/react-virtualized/issues/1176~~
Edit: the issue can also be fixed by properly destructuring title. Thanks to @Razboy20 for the suggestion

https://github.com/user-attachments/assets/2008eae2-c36d-4a4d-8b8d-3ada8eb4077f


https://github.com/user-attachments/assets/a6c9a0b1-6b4c-4e0b-af19-b1fd54ee1f00

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/284)
<!-- Reviewable:end -->
