### PR TITLE
fix: duplicate schedule name regex no longer grabs trailing white space

### DIFF
--- a/src/pages/background/lib/handleDuplicate.ts
+++ b/src/pages/background/lib/handleDuplicate.ts
@@ -20,7 +20,7 @@ export default async function handleDuplicate(scheduleName: string): Promise<str
 
     // Extract base name and existing index
     const match = scheduleName.match(regex);
-    const baseName = match && match[1] ? match[1] : scheduleName;
+    const baseName = match && match[1] ? match[1].trim() : scheduleName;
 
     // Extract number from parentheses and increment
     let index = match && match[2] ? parseInt(match[2].slice(1, -1), 10) + 1 : 1;


### PR DESCRIPTION
- fix: Duplicating a schedule no longer grabs trailing spaces between a given name and its duplicate counter. `trim()` is applied to any valid regex matching for `baseName`

Normal schedule name:
<img width="255" alt="image" src="https://github.com/user-attachments/assets/30522a41-8abb-45a1-97eb-5355793bdba7">

Schedule name with extra space:
<img width="249" alt="image" src="https://github.com/user-attachments/assets/81ef7c55-671c-4f51-ab2e-b878267853dd">

To reproduce this with the current build, do the following:
1. Create 3 new schedules (New Schedule, New Schedule (1), New Schedule (2) )
2. Duplicate New Schedule (1)
3. This should create a schedule called `New Schedule  (2)` but appear like `New Schedule (2)` in the list, unless editing its name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/286)
<!-- Reviewable:end -->
