### PR TITLE
fix: show calendar in active window

### DIFF
--- a/src/pages/background/handler/calendarBackgroundHandler.ts
+++ b/src/pages/background/handler/calendarBackgroundHandler.ts
@@ -5,7 +5,9 @@ import type { CalendarBackgroundMessages } from '@shared/messages/CalendarMessag
 import type { MessageHandler } from 'chrome-extension-toolkit';
 
 const getAllTabInfos = async () => {
-    const openTabs = (await chrome.tabs.query({})).filter((tab): tab is TabWithId => tab.id !== undefined);
+    const openTabs = (await chrome.tabs.query({ currentWindow: true })).filter(
+        (tab): tab is TabWithId => tab.id !== undefined
+    );
     const results = await Promise.allSettled(openTabs.map(tab => tabs.getTabInfo(undefined, tab.id)));
 
     type TabInfo = PromiseFulfilledResult<Awaited<ReturnType<typeof tabs.getTabInfo>>>;
@@ -28,10 +30,14 @@ const calendarBackgroundHandler: MessageHandler<CalendarBackgroundMessages> = {
         const openCalendarTabInfo = allTabs.find(tab => tab.url?.startsWith(calendarUrl));
 
         if (openCalendarTabInfo !== undefined) {
-            const tabid = openCalendarTabInfo.tab.id;
+            const tabId = openCalendarTabInfo.tab.id;
 
-            chrome.tabs.update(tabid, { active: true });
-            if (uniqueId !== undefined) await tabs.openCoursePopup({ uniqueId }, tabid);
+            await chrome.tabs.update(tabId, { active: true });
+            await chrome.scripting.executeScript({
+                target: { tabId },
+                func: () => window.focus(),
+            });
+            if (uniqueId !== undefined) await tabs.openCoursePopup({ uniqueId }, tabId);
 
             sendResponse(openCalendarTabInfo.tab);
         } else {

--- a/src/pages/background/handler/calendarBackgroundHandler.ts
+++ b/src/pages/background/handler/calendarBackgroundHandler.ts
@@ -5,9 +5,7 @@ import type { CalendarBackgroundMessages } from '@shared/messages/CalendarMessag
 import type { MessageHandler } from 'chrome-extension-toolkit';
 
 const getAllTabInfos = async () => {
-    const openTabs = (await chrome.tabs.query({ currentWindow: true })).filter(
-        (tab): tab is TabWithId => tab.id !== undefined
-    );
+    const openTabs = (await chrome.tabs.query({})).filter((tab): tab is TabWithId => tab.id !== undefined);
     const results = await Promise.allSettled(openTabs.map(tab => tabs.getTabInfo(undefined, tab.id)));
 
     type TabInfo = PromiseFulfilledResult<Awaited<ReturnType<typeof tabs.getTabInfo>>>;
@@ -30,14 +28,11 @@ const calendarBackgroundHandler: MessageHandler<CalendarBackgroundMessages> = {
         const openCalendarTabInfo = allTabs.find(tab => tab.url?.startsWith(calendarUrl));
 
         if (openCalendarTabInfo !== undefined) {
-            const tabId = openCalendarTabInfo.tab.id;
+            const tabid = openCalendarTabInfo.tab.id;
 
-            await chrome.tabs.update(tabId, { active: true });
-            await chrome.scripting.executeScript({
-                target: { tabId },
-                func: () => window.focus(),
-            });
-            if (uniqueId !== undefined) await tabs.openCoursePopup({ uniqueId }, tabId);
+            await chrome.tabs.update(tabid, { active: true });
+            await chrome.windows.update(openCalendarTabInfo.tab.windowId, { focused: true, drawAttention: true });
+            if (uniqueId !== undefined) await tabs.openCoursePopup({ uniqueId }, tabid);
 
             sendResponse(openCalendarTabInfo.tab);
         } else {


### PR DESCRIPTION
Previously, we tried to have one global calendar page. One problem with that is that the tab could exist but might be in a window that can't be focused. When that happens, a user has no visual explanation of why the calendar refuses to open.

This PR makes the calendar page only show once per window, instead of once per browser.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/312)
<!-- Reviewable:end -->
