### PR TITLE
feat: disable/some actions when no instructor

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -95,6 +95,12 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
             const url = `https://utdirect.utexas.edu/apps/student/coursedocs/nlogon/?year=&semester=&department=${department}&course_number=${courseNumber}&course_title=&unique=&instructor_first=${firstName}&instructor_last=${lastName}&course_type=In+Residence&search=Search`;
             openNewTab({ url });
         }
+
+        // Show the course's syllabi when no instructors listed
+        if (instructors.length === 0) {
+            const url = `https://utdirect.utexas.edu/apps/student/coursedocs/nlogon/?year=&semester=&department=${department}&course_number=${courseNumber}&course_title=&unique=&instructor_first=&instructor_last=&course_type=In+Residence&search=Search`;
+            openNewTab({ url });
+        }
     };
 
     const handleAddOrRemoveCourse = async () => {
@@ -199,10 +205,22 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
                     }}
                 />
                 <Divider size='1.75rem' orientation='vertical' />
-                <Button variant='outline' color='ut-blue' icon={Reviews} onClick={handleOpenRateMyProf}>
+                <Button
+                    variant='outline'
+                    color='ut-blue'
+                    icon={Reviews}
+                    onClick={handleOpenRateMyProf}
+                    disabled={instructors.length === 0}
+                >
                     RateMyProf
                 </Button>
-                <Button variant='outline' color='ut-teal' icon={Mood} onClick={handleOpenCES}>
+                <Button
+                    variant='outline'
+                    color='ut-teal'
+                    icon={Mood}
+                    onClick={handleOpenCES}
+                    disabled={instructors.length === 0}
+                >
                     CES
                 </Button>
                 <Button variant='outline' color='ut-orange' icon={Description} onClick={handleOpenPastSyllabi}>


### PR DESCRIPTION
When a course has no instructors, we can't show the CES or RateMyProfessor, but we can show course-wide syllabus data.

before:

https://github.com/user-attachments/assets/78476f88-6ce5-46a5-8a6b-ad4c27826783

after:

https://github.com/user-attachments/assets/4f6fc55a-1f6c-4848-8d4c-3a1dceb5011d



<sub><a href="https://huly.app/guest/longhorndevelopers?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzExM2Y0MGNlNzQ0ODdkZDQzZGE1OWQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHVicmF6Ym95LWxvbmdob3JuZGV2ZS02NzA4NWI0ZS1kMjIzZmMxZDczLThjYzI3NiJ9.0RwWB2bGnV-uHPRsiUyeWOifKicDwH6gGGNaBEfYsX4">Huly&reg;: <b>UTRP-315</b></a></sub>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/319)
<!-- Reviewable:end -->
