### PR TITLE
feat: add explanation to grade distribution

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -245,7 +245,7 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                                     </option>
                                 ))}
                         </select>
-                        <Link variant='mini' href={UT_GRADE_DISTRIBUTION_URL} className='link'>
+                        <Link variant='small' href={UT_GRADE_DISTRIBUTION_URL} className='link'>
                             About the data
                         </Link>
                     </div>

--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -1,6 +1,7 @@
 import type { Course } from '@shared/types/Course';
 import type { Distribution, LetterGrade } from '@shared/types/Distribution';
 import { extendedColors } from '@shared/types/ThemeColors';
+import Link from '@views/components/common/Link';
 import Text from '@views/components/common/Text/Text';
 import {
     NoDataError,
@@ -12,6 +13,8 @@ import HighchartsReact from 'highcharts-react-official';
 import type { ChangeEvent } from 'react';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
+
+const UT_GRADE_DISTRIBUTION_URL = 'https://reports.utexas.edu/spotlight-data/ut-course-grade-distributions';
 
 interface GradeDistributionProps {
     course: Course;
@@ -242,6 +245,9 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                                     </option>
                                 ))}
                         </select>
+                        <Link variant='mini' href={UT_GRADE_DISTRIBUTION_URL} className='link'>
+                            About the data
+                        </Link>
                     </div>
                     {distributions[semester] && !distributions[semester]!.instructorIncluded && (
                         <div className='mt-3 flex flex-wrap content-center items-center self-stretch justify-center gap-3'>


### PR DESCRIPTION
# Improve UX by Adding an Explanation to the Grade Distribution Chart

- The **Other** category in the grade distribution popup is somewhat ambiguous for the users, so I added a simple description underneath the chart to explain its meaning.
- I referenced the official [UT Course Grade Distribution](https://reports.utexas.edu/spotlight-data/ut-course-grade-distributions) to write this explanation. You can find their original explanation in the **(?)** help popup.

## Before

![before](https://github.com/user-attachments/assets/52d65a20-e113-4dc0-bbb9-ac4b63e97d48)

## After

![after](https://github.com/user-attachments/assets/88ca96bb-e99b-4ed4-842d-99b89c8bc02b)



<sub><a href="https://huly.app/guest/longhorndevelopers?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzEyNmVkN2NlNzQ0ODdkZDQzZGJhMjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHVicmF6Ym95LWxvbmdob3JuZGV2ZS02NzA4NWI0ZS1kMjIzZmMxZDczLThjYzI3NiJ9.rrusc9TpTXQBSCGh3mn3tuyer4_48rSP-oaMg7VuM8Y">Huly&reg;: <b>UTRP-321</b></a></sub>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/325)
<!-- Reviewable:end -->
