### PR TITLE
feat: Add linkedin social to calendar

### DIFF
--- a/src/views/components/calendar/CalendarFooter.tsx
+++ b/src/views/components/calendar/CalendarFooter.tsx
@@ -24,8 +24,11 @@ export default function CalendarFooter(): JSX.Element {
                 <Link className='linkanimate' href='https://github.com/Longhorn-Developers'>
                     <GithubIcon className='h-6 w-6' />
                 </Link>
-                <Link className='linkanimate' href='https://www.linkedin.com/company/longhorn-developers/posts/?feedView=all'>
-                    <LinkedinIcon className='h-6 w-6'/>
+                <Link
+                    className='linkanimate'
+                    href='https://www.linkedin.com/company/longhorn-developers/posts/?feedView=all'
+                >
+                    <LinkedinIcon className='h-6 w-6' />
                 </Link>
             </div>
             <p className='text-2.5 text-ut-concrete font-light tracking-wide'>

--- a/src/views/components/calendar/CalendarFooter.tsx
+++ b/src/views/components/calendar/CalendarFooter.tsx
@@ -28,7 +28,7 @@ export default function CalendarFooter(): JSX.Element {
                     className='linkanimate'
                     href='https://www.linkedin.com/company/longhorn-developers/posts/?feedView=all'
                 >
-                    <LinkedinIcon className='h-6 w-6' />
+                    <LinkedinIcon className='h-6 w-6 -mx-0.75' />
                 </Link>
             </div>
             <p className='text-2.5 text-ut-concrete font-light tracking-wide'>

--- a/src/views/components/calendar/CalendarFooter.tsx
+++ b/src/views/components/calendar/CalendarFooter.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import DiscordIcon from '~icons/bi/discord';
 import GithubIcon from '~icons/ri/github-fill';
 import InstagramIcon from '~icons/ri/instagram-line';
+import LinkedinIcon from '~icons/ri/linkedin-box-fill';
 
 import Link from '../common/Link';
 
@@ -22,6 +23,9 @@ export default function CalendarFooter(): JSX.Element {
                 </Link>
                 <Link className='linkanimate' href='https://github.com/Longhorn-Developers'>
                     <GithubIcon className='h-6 w-6' />
+                </Link>
+                <Link className='linkanimate' href='https://www.linkedin.com/company/longhorn-developers/posts/?feedView=all'>
+                    <LinkedinIcon className='h-6 w-6'/>
                 </Link>
             </div>
             <p className='text-2.5 text-ut-concrete font-light tracking-wide'>


### PR DESCRIPTION
Adds linkedin icon to the footer that links to longhorn developer linkedin page.



<sub><a href="https://huly.app/guest/longhorndevelopers?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE2ZWI4OTRjMjRlYTI4ODIwMzVhMjAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHVicmF6Ym95LWxvbmdob3JuZGV2ZS02NzA4NWI0ZS1kMjIzZmMxZDczLThjYzI3NiJ9.2X3SbFAoW291tBTR3Oiev6qCbjpB9TJ1p-L5dmtonDc">Huly&reg;: <b>UTRP-352</b></a></sub>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/368)
<!-- Reviewable:end -->
