### PR TITLE
chore: Change color UTRP Red to #d10000

### DIFF
--- a/src/shared/types/ThemeColors.ts
+++ b/src/shared/types/ThemeColors.ts
@@ -15,7 +15,7 @@ export const colors = {
         gray: '#9CADB7',
         offwhite: '#D6D2C4',
         concrete: '#95A5A6',
-        red: '#B91C1C', //   Not sure if this should be here, but it's used for remove course, and add course is ut-green
+        red: '#d10000', //   Not sure if this should be here, but it's used for remove course, and add course is ut-green
     },
     theme: {
         red: '#BF0000',


### PR DESCRIPTION
Resolves #346

Changed UTRP Red within ut: { } in src>shared>types>ThemeColors.ts to #d10000



<sub><a href="https://huly.app/guest/longhorndevelopers?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE2ZWY2NTRjMjRlYTI4ODIwMzg3NjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHVicmF6Ym95LWxvbmdob3JuZGV2ZS02NzA4NWI0ZS1kMjIzZmMxZDczLThjYzI3NiJ9.b4aB-RF3wusOAC99MDFMCAOPf-vQcuDjBxM9x7Ux7n8">Huly&reg;: <b>UTRP-357</b></a></sub>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/373)
<!-- Reviewable:end -->
