### PR TITLE
feat(popup): popup transparent fill

### DIFF
--- a/src/views/components/PopupMain.tsx
+++ b/src/views/components/PopupMain.tsx
@@ -88,12 +88,22 @@ export default function PopupMain(): JSX.Element {
                         <button className='bg-ut-burntorange px-2 py-1.25 btn' onClick={handleCalendarOpenOnClick}>
                             <CalendarIcon className='size-6 text-white' />
                         </button>
-                        <button className='bg-transparent px-2 py-1.25 btn' onClick={handleOpenOptions}>
+                        <Button
+                            variant='single'
+                            color='ut-black'
+                            className='bg-transparent px-2 py-1.25 btn'
+                            onClick={handleOpenOptions}
+                        >
                             <SettingsIcon className='size-6 color-ut-black' />
-                        </button>
-                        <button className='bg-transparent px-2 py-1.25 btn' onClick={openReportWindow}>
+                        </Button>
+                        <Button
+                            variant='single'
+                            color='ut-black'
+                            className='bg-transparent px-2 py-1.25 btn'
+                            onClick={openReportWindow}
+                        >
                             <Feedback className='size-6 color-ut-black' />
-                        </button>
+                        </Button>
                     </div>
                 </div>
             </div>

--- a/src/views/components/PopupMain.tsx
+++ b/src/views/components/PopupMain.tsx
@@ -88,22 +88,8 @@ export default function PopupMain(): JSX.Element {
                         <button className='bg-ut-burntorange px-2 py-1.25 btn' onClick={handleCalendarOpenOnClick}>
                             <CalendarIcon className='size-6 text-white' />
                         </button>
-                        <Button
-                            variant='single'
-                            color='ut-black'
-                            className='bg-transparent px-2 py-1.25 btn'
-                            onClick={handleOpenOptions}
-                        >
-                            <SettingsIcon className='size-6 color-ut-black' />
-                        </Button>
-                        <Button
-                            variant='single'
-                            color='ut-black'
-                            className='bg-transparent px-2 py-1.25 btn'
-                            onClick={openReportWindow}
-                        >
-                            <Feedback className='size-6 color-ut-black' />
-                        </Button>
+                        <Button variant='single' color='ut-black' icon={SettingsIcon} onClick={handleOpenOptions} />
+                        <Button variant='single' color='ut-black' icon={Feedback} onClick={openReportWindow} />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #350

Updated the pop-up window so that both the settings and report buttons have a transparent fill when hovered over

Before:

https://github.com/user-attachments/assets/71f46988-9318-4979-854c-f0b2b762a05b

After:

https://github.com/user-attachments/assets/16ffe500-052e-4876-b87f-17c9d84b80a4



<sub><a href="https://huly.app/guest/longhorndevelopers?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE2ZjFkZTRjMjRlYTI4ODIwMzlkZGMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHVicmF6Ym95LWxvbmdob3JuZGV2ZS02NzA4NWI0ZS1kMjIzZmMxZDczLThjYzI3NiJ9.Gz045GVLBllAo7rZjkWIixJa7cc8VStp7ctMDD1y_F4">Huly&reg;: <b>UTRP-358</b></a></sub>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/374)
<!-- Reviewable:end -->
