### PR TITLE
fix: remove screenshot padding class for png download for #344

### DIFF
--- a/src/views/components/calendar/CalendarCourseCell.tsx
+++ b/src/views/components/calendar/CalendarCourseCell.tsx
@@ -76,7 +76,7 @@ export default function CalendarCourseCell({
     return (
         <div
             className={clsx(
-                'h-full w-0 flex justify-center rounded p-x-2 p-y-1.2 cursor-pointer screenshot:p-1.5 hover:shadow-md transition-shadow-100 ease-out',
+                'h-full w-0 flex justify-center rounded p-x-2 p-y-1.2 cursor-pointer hover:shadow-md transition-shadow-100 ease-out',
                 {
                     'min-w-full': timeAndLocation,
                     'w-full': !timeAndLocation,


### PR DESCRIPTION
Removed padding screenshot class from calendar course cell to prevent cutoff issue for 1 hr courses



<sub><a href="https://huly.app/guest/longhorndevelopers?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE3MTk1MTRjMjRlYTI4ODIwNGM3NzkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHVicmF6Ym95LWxvbmdob3JuZGV2ZS02NzA4NWI0ZS1kMjIzZmMxZDczLThjYzI3NiJ9.8ezO9XgnfkoJI6qF_EkVoJBgpSEJv_vTqSIOt_ONbHk">Huly&reg;: <b>UTRP-360</b></a></sub>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/376)
<!-- Reviewable:end -->
