### PR TITLE
fix(ui): main popup now shows 0 for empty schedule

### DIFF
--- a/src/pages/background/background.ts
+++ b/src/pages/background/background.ts
@@ -59,15 +59,11 @@ messageListener.listen();
 UserScheduleStore.listen('schedules', async schedules => {
     const index = await UserScheduleStore.get('activeIndex');
     const numCourses = schedules.newValue[index]?.courses?.length;
-    if (!numCourses) return;
-
-    updateBadgeText(numCourses);
+    updateBadgeText(numCourses || 0);
 });
 
 UserScheduleStore.listen('activeIndex', async ({ newValue }) => {
     const schedules = await UserScheduleStore.get('schedules');
     const numCourses = schedules[newValue]?.courses?.length;
-    if (!numCourses) return;
-
-    updateBadgeText(numCourses);
+    updateBadgeText(numCourses || 0);
 });

--- a/src/shared/util/updateBadgeText.ts
+++ b/src/shared/util/updateBadgeText.ts
@@ -14,7 +14,7 @@ export const BADGE_LIMIT = 10;
  */
 export default function updateBadgeText(value: number): void {
     let badgeText = '';
-    if (value > 0) {
+    if (value >= 0) {
         if (value > BADGE_LIMIT) {
             badgeText = `${BADGE_LIMIT}+`;
         } else {


### PR DESCRIPTION
Fixed the issue where the Main popup icon was not showing the number 0 when a schedule with 0 hours was selected.

![image](https://github.com/user-attachments/assets/a21cd522-a297-41d4-933c-ad4ac576c324)

![image](https://github.com/user-attachments/assets/7025f74b-07e1-4158-b547-22c30c40d2b6)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/395)
<!-- Reviewable:end -->

Resolves #343 