### PR TITLE
fix(ui): placeholder text for no instructor course #400

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -131,7 +131,7 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
                 </div>
                 <div className='flex items-center gap-2'>
                     {instructors.length > 0 ? (
-                        <Text variant='h4' as='p' className='items-center justify-center'>
+                        <Text variant='h4' as='p'>
                             with{' '}
                             {instructors
                                 .map(instructor => (

--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -130,7 +130,7 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
                     </button>
                 </div>
                 <div className='flex items-center gap-2'>
-                    {instructors.length > 0 && (
+                    {instructors.length > 0 ? (
                         <Text variant='h4' as='p' className='items-center justify-center'>
                             with{' '}
                             {instructors
@@ -145,6 +145,10 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
                                     </Link>
                                 ))
                                 .flatMap((el, i) => (i === 0 ? [el] : [', ', el]))}
+                        </Text>
+                    ) : (
+                        <Text variant='h4' as='p'>
+                            (No instructor has been provided)
                         </Text>
                     )}
                     <div className='flex items-center gap-1'>


### PR DESCRIPTION
Resolves #400 

Previously, a course popup that did not have an instructor would simply not display anything for instructors. Now, if a course has no instructor, a message "(No instructor has been provided)" will be displayed instead.

<img width="434" alt="image" src="https://github.com/user-attachments/assets/da608d79-6bf0-48e1-b1ac-31e00885d653">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/402)
<!-- Reviewable:end -->
