### PR TITLE
fix(ui): multiple instructors are formatted properly, displays last name only, and are capitalized in all course blocks (#342)

### DIFF
--- a/src/views/components/common/PopupCourseBlock.tsx
+++ b/src/views/components/common/PopupCourseBlock.tsx
@@ -79,7 +79,9 @@ export default function PopupCourseBlock({
             </div>
             <Text className={clsx('flex-1 py-3.5 truncate', fontColor)} variant='h1-course'>
                 <span className='px-0.5 font-450'>{formattedUniqueId}</span> {course.department} {course.number} &ndash;{' '}
-                {course.instructors.length === 0 ? 'Unknown' : course.instructors.map(v => v.lastName)}
+                {course.instructors.length === 0
+                    ? 'Unknown'
+                    : course.instructors.map(v => v.toString({ format: 'last', case: 'capitalize' })).join('; ')}
             </Text>
             {enableCourseStatusChips && course.status !== Status.OPEN && (
                 <div

--- a/src/views/components/common/PopupCourseBlock.tsx
+++ b/src/views/components/common/PopupCourseBlock.tsx
@@ -79,7 +79,7 @@ export default function PopupCourseBlock({
             </div>
             <Text className={clsx('flex-1 py-3.5 truncate', fontColor)} variant='h1-course'>
                 <span className='px-0.5 font-450'>{formattedUniqueId}</span> {course.department} {course.number}
-                {course.instructors.length > 0 ? ' - ' : ''}
+                {course.instructors.length > 0 ? <> &ndash; </> : ''}
                 {course.instructors.map(v => v.toString({ format: 'last', case: 'capitalize' })).join('; ')}
             </Text>
             {enableCourseStatusChips && course.status !== Status.OPEN && (

--- a/src/views/components/common/PopupCourseBlock.tsx
+++ b/src/views/components/common/PopupCourseBlock.tsx
@@ -78,10 +78,9 @@ export default function PopupCourseBlock({
                 <DragIndicatorIcon className='h-6 w-6 text-white' />
             </div>
             <Text className={clsx('flex-1 py-3.5 truncate', fontColor)} variant='h1-course'>
-                <span className='px-0.5 font-450'>{formattedUniqueId}</span> {course.department} {course.number} &ndash;{' '}
-                {course.instructors.length === 0
-                    ? 'Unknown'
-                    : course.instructors.map(v => v.toString({ format: 'last', case: 'capitalize' })).join('; ')}
+                <span className='px-0.5 font-450'>{formattedUniqueId}</span> {course.department} {course.number}
+                {course.instructors.length > 0 ? ' - ' : ''}
+                {course.instructors.map(v => v.toString({ format: 'last', case: 'capitalize' })).join('; ')}
             </Text>
             {enableCourseStatusChips && course.status !== Status.OPEN && (
                 <div

--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -37,7 +37,8 @@ interface HeadingAndActionProps {
  * @param str - The string to be capitalized.
  * @returns The capitalized string.
  */
-const capitalizeString = (str: string) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+const capitalizeString: (str: string) => string = (str: string) =>
+    str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 
 /**
  * Renders the heading component for the CoursePopup component.

--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -37,8 +37,7 @@ interface HeadingAndActionProps {
  * @param str - The string to be capitalized.
  * @returns The capitalized string.
  */
-const capitalizeString: (str: string) => string = (str: string) =>
-    str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+const capitalizeString = (str: string) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 
 /**
  * Renders the heading component for the CoursePopup component.

--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -55,11 +55,8 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
     const formattedUniqueId = uniqueId.toString().padStart(5, '0');
     const isInCalendar = useCalendar();
 
-    const getInstructorFullName = (instructor: Instructor) => {
-        const { firstName = '', lastName = '' } = instructor;
-        if (firstName === '') return capitalizeString(lastName);
-        return `${capitalizeString(firstName)} ${capitalizeString(lastName)}`;
-    };
+    const getInstructorFullName = (instructor: Instructor) =>
+        instructor.toString({ format: 'first_last', case: 'capitalize' });
 
     const getBuildingUrl = (building: string) =>
         `https://utdirect.utexas.edu/apps/campus/buildings/nlogon/maps/UTM/${building}`;

--- a/src/views/hooks/useFlattenedCourseSchedule.ts
+++ b/src/views/hooks/useFlattenedCourseSchedule.ts
@@ -105,7 +105,7 @@ function extractCourseInfo(course: Course) {
     if (course.instructors.length >= 0) {
         courseDeptAndInstr += ` - `;
         courseDeptAndInstr += course.instructors
-            .map(instructor => `${instructor.toString({ format: 'first_last', case: 'capitalize' })}`)
+            .map(instructor => `${instructor.toString({ format: 'last', case: 'capitalize' })}`)
             .join(', ');
     }
 

--- a/src/views/hooks/useFlattenedCourseSchedule.ts
+++ b/src/views/hooks/useFlattenedCourseSchedule.ts
@@ -95,13 +95,6 @@ function extractCourseInfo(course: Course) {
 
     let courseDeptAndInstr = `${course.department} ${course.number}`;
 
-    /*
-    const mainInstructor = course.instructors[0];
-    if (mainInstructor) {
-        courseDeptAndInstr += ` – ${mainInstructor.toString({ format: 'first_last', case: 'capitalize' })}`;
-    }
-    */
-
     if (course.instructors.length >= 0) {
         courseDeptAndInstr += ` - `;
         courseDeptAndInstr += course.instructors

--- a/src/views/hooks/useFlattenedCourseSchedule.ts
+++ b/src/views/hooks/useFlattenedCourseSchedule.ts
@@ -95,9 +95,18 @@ function extractCourseInfo(course: Course) {
 
     let courseDeptAndInstr = `${course.department} ${course.number}`;
 
+    /*
     const mainInstructor = course.instructors[0];
     if (mainInstructor) {
         courseDeptAndInstr += ` – ${mainInstructor.toString({ format: 'first_last', case: 'capitalize' })}`;
+    }
+    */
+
+    if (course.instructors.length >= 0) {
+        courseDeptAndInstr += ` - `;
+        courseDeptAndInstr += course.instructors
+            .map(instructor => `${instructor.toString({ format: 'first_last', case: 'capitalize' })}`)
+            .join(', ');
     }
 
     return { status, courseDeptAndInstr, meetings, course };

--- a/src/views/hooks/useFlattenedCourseSchedule.ts
+++ b/src/views/hooks/useFlattenedCourseSchedule.ts
@@ -95,7 +95,7 @@ function extractCourseInfo(course: Course) {
 
     let courseDeptAndInstr = `${course.department} ${course.number}`;
 
-    if (course.instructors.length >= 0) {
+    if (course.instructors.length > 0) {
         courseDeptAndInstr += ` - `;
         courseDeptAndInstr += course.instructors
             .map(instructor => instructor.toString({ format: 'last', case: 'capitalize' }))

--- a/src/views/hooks/useFlattenedCourseSchedule.ts
+++ b/src/views/hooks/useFlattenedCourseSchedule.ts
@@ -99,7 +99,7 @@ function extractCourseInfo(course: Course) {
         courseDeptAndInstr += ` - `;
         courseDeptAndInstr += course.instructors
             .map(instructor => instructor.toString({ format: 'last', case: 'capitalize' }))
-            .join(', ');
+            .join('; ');
     }
 
     return { status, courseDeptAndInstr, meetings, course };

--- a/src/views/hooks/useFlattenedCourseSchedule.ts
+++ b/src/views/hooks/useFlattenedCourseSchedule.ts
@@ -96,7 +96,7 @@ function extractCourseInfo(course: Course) {
     let courseDeptAndInstr = `${course.department} ${course.number}`;
 
     if (course.instructors.length > 0) {
-        courseDeptAndInstr += ` - `;
+        courseDeptAndInstr += ' \u2013 ';
         courseDeptAndInstr += course.instructors
             .map(instructor => instructor.toString({ format: 'last', case: 'capitalize' }))
             .join('; ');


### PR DESCRIPTION
This PR resolves (#342)
The issue was improper formatting of multiple instructors in course blocks in the calendar and main extension popup.

Here are the changes:
1. Instructor names in course blocks now only display last names
2. Instructor names are spaced with a semicolon in the calendar and main extension popup

Calendar Course Block after the changes:
![image](https://github.com/user-attachments/assets/647fc652-5a0d-4541-ad5c-7a817df20dfc)

Main Extension Popup Course Block after the changes:
![image](https://github.com/user-attachments/assets/31be4dda-5d9c-421e-a7a2-831ef6e22f0f)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/403)
<!-- Reviewable:end -->
