### PR TITLE
style(ui): changed tick marks to match x-axis

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -137,7 +137,7 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
             },
             categories: ['A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'C-', 'D+', 'D', 'D-', 'F', 'Other'],
             tickInterval: 1,
-            tickWidth: 1.5,
+            tickWidth: 1,
             tickLength: 10,
             tickColor: '#9CADB7',
             crosshair: true,


### PR DESCRIPTION
Resolves #334 
changed Grade Distribution Chart x-axis ticks stroke width to match Figma
Ticks were bigger than x-axis before and I changed the tick length to 1px to fix the inconsistency of tick to x-axis sizes.

Before:
<img width="214" alt="Screenshot 2024-11-18 at 8 36 16 AM" src="https://github.com/user-attachments/assets/f6ef315a-0109-4ada-9963-a258d7859b9b">

After:
<img width="214" alt="Screenshot 2024-11-18 at 8 37 11 AM" src="https://github.com/user-attachments/assets/d42826dd-1b37-442c-942c-81234280e4d4">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/440)
<!-- Reviewable:end -->
