### PR TITLE
feat(ui): add new search link

### DIFF
--- a/src/views/components/CourseCatalogMain.tsx
+++ b/src/views/components/CourseCatalogMain.tsx
@@ -2,6 +2,7 @@ import type { Course, ScrapedRow } from '@shared/types/Course';
 import ExtensionRoot from '@views/components/common/ExtensionRoot/ExtensionRoot';
 import AutoLoad from '@views/components/injected/AutoLoad/AutoLoad';
 import CourseCatalogInjectedPopup from '@views/components/injected/CourseCatalogInjectedPopup/CourseCatalogInjectedPopup';
+import NewSearchLink from '@views/components/injected/NewSearchLink';
 import RecruitmentBanner from '@views/components/injected/RecruitmentBanner/RecruitmentBanner';
 import TableHead from '@views/components/injected/TableHead';
 import TableRow from '@views/components/injected/TableRow/TableRow';
@@ -61,6 +62,7 @@ export default function CourseCatalogMain({ support }: Props): JSX.Element | nul
 
     return (
         <ExtensionRoot>
+            <NewSearchLink />
             <RecruitmentBanner />
             <TableHead>Plus</TableHead>
             {rows.map(

--- a/src/views/components/injected/NewSearchLink.tsx
+++ b/src/views/components/injected/NewSearchLink.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * This creates a 'Begin a new search' link above the course catalog table.
+ *
+ * @returns a react portal to the new link container or null if the container is not found.
+ */
+export default function NewSearchLink() {
+    const [container, setContainer] = useState<HTMLElement | null>(null);
+    const newContainerId = 'ut-registration-plus-new-search-link';
+
+    const searchLink = document.querySelector('#bottom_nav > p:nth-child(2)');
+    const linkContent = {
+        href: searchLink?.querySelector('a')?.href,
+        title: searchLink?.querySelector('a')?.title,
+        text: searchLink?.querySelector('a')?.textContent,
+    };
+
+    useEffect(() => {
+        if (document.getElementById(newContainerId)) {
+            return;
+        }
+
+        const innerBody = document.querySelector('#inner_body');
+        if (!innerBody) {
+            return;
+        }
+
+        const containerElement = document.createElement('div');
+        containerElement.setAttribute('id', newContainerId);
+
+        innerBody.prepend(containerElement);
+        setContainer(containerElement);
+    }, []);
+
+    if (!container) {
+        return null;
+    }
+
+    return createPortal(
+        <p>
+            <a href={linkContent.href} title={linkContent.title}>
+                {linkContent.text}
+            </a>
+        </p>,
+        container
+    );
+}


### PR DESCRIPTION
This PR resolves issue #411.

### Add a "begin a new search" link above the Course Catalog Table on the Course Schedule page.
This makes it easier to begin a new search rather than scrolling to the bottom of the page, which is frustrating, especially when autoload is enabled.

#### Before:
![without-search-link](https://github.com/user-attachments/assets/f67d612f-439d-43fe-9adc-2910e6658ae4)

#### After:
![with-new-search-link](https://github.com/user-attachments/assets/f18e72d0-ab06-4477-8420-914e9ad6a85e)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/456)
<!-- Reviewable:end -->
