### PR TITLE
feat: add open calendar button

### DIFF
--- a/src/views/components/settings/Settings.tsx
+++ b/src/views/components/settings/Settings.tsx
@@ -21,11 +21,13 @@ import useSchedules from '@views/hooks/useSchedules';
 // import { CourseCatalogScraper } from '@views/lib/CourseCatalogScraper';
 // import getCourseTableRows from '@views/lib/getCourseTableRows';
 import { GitHubStatsService, LONGHORN_DEVELOPERS_ADMINS, LONGHORN_DEVELOPERS_SWE } from '@views/lib/getGitHubStats';
+import { openTabFromContentScript } from '@views/lib/openNewTabFromContentScript';
 // import { SiteSupport } from '@views/lib/getSiteSupport';
 import clsx from 'clsx';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import IconoirGitFork from '~icons/iconoir/git-fork';
+import CalendarIcon from '~icons/material-symbols/calendar-month';
 // import { ExampleCourse } from 'src/stories/components/ConflictsWithWarning.stories';
 import DeleteForeverIcon from '~icons/material-symbols/delete-forever';
 
@@ -39,10 +41,18 @@ const DISPLAY_PREVIEWS = false;
 const PREVIEW_SECTION_DIV_CLASSNAME = DISPLAY_PREVIEWS ? 'w-1/2 space-y-4' : 'flex-grow space-y-4';
 
 const manifest = chrome.runtime.getManifest();
-const LDIconURL = new URL('/src/assets/LD-icon.png', import.meta.url).href;
 
 const gitHubStatsService = new GitHubStatsService();
 const includeMergedPRs = false;
+
+/**
+ * Opens the calendar page in a new tab.
+ * @returns A promise that resolves when the options page is opened.
+ */
+const handleOpenCalendar = async (): Promise<void> => {
+    const url = chrome.runtime.getURL('/calendar.html');
+    await openTabFromContentScript(url);
+};
 
 /**
  * Custom hook for enabling developer mode.
@@ -256,8 +266,8 @@ export default function Settings(): JSX.Element {
             <header className='flex items-center gap-5 overflow-x-auto overflow-y-hidden border-b border-ut-offwhite px-7 py-4 md:overflow-x-hidden'>
                 <LargeLogo />
                 <Divider className='mx-2 self-center md:mx-4' size='2.5rem' orientation='vertical' />
-                <Text variant='h1' className='flex-1 text-ut-burntorange'>
-                    UTRP SETTINGS & CREDITS PAGE
+                <Text variant='h1' className='flex-1 text-ut-burntorange normal-case!'>
+                    Settings and Credits
                 </Text>
                 <div className='hidden flex-row items-center justify-end gap-6 screenshot:hidden lg:flex'>
                     <Button variant='single' color='theme-black' onClick={handleChangelogOnClick}>
@@ -266,7 +276,9 @@ export default function Settings(): JSX.Element {
                             v{manifest.version} - {process.env.NODE_ENV}
                         </Text>
                     </Button>
-                    <img src={LDIconURL} alt='LD Icon' className='h-10 w-10 rounded-lg' />
+                    <Button variant='filled' icon={CalendarIcon} color='ut-burntorange' onClick={handleOpenCalendar}>
+                        Calendar
+                    </Button>
                 </div>
             </header>
 

--- a/src/views/components/settings/Settings.tsx
+++ b/src/views/components/settings/Settings.tsx
@@ -4,6 +4,7 @@ import { deleteAllSchedules } from '@pages/background/lib/deleteSchedule';
 import exportSchedule from '@pages/background/lib/exportSchedule';
 import importSchedule from '@pages/background/lib/importSchedule';
 import { Trash } from '@phosphor-icons/react';
+import { background } from '@shared/messages';
 import { initSettings, OptionsStore } from '@shared/storage/OptionsStore';
 import { UserScheduleStore } from '@shared/storage/UserScheduleStore';
 import { downloadBlob } from '@shared/util/downloadBlob';
@@ -22,15 +23,12 @@ import useSchedules from '@views/hooks/useSchedules';
 // import { CourseCatalogScraper } from '@views/lib/CourseCatalogScraper';
 // import getCourseTableRows from '@views/lib/getCourseTableRows';
 import { GitHubStatsService, LONGHORN_DEVELOPERS_ADMINS, LONGHORN_DEVELOPERS_SWE } from '@views/lib/getGitHubStats';
-import { openTabFromContentScript } from '@views/lib/openNewTabFromContentScript';
 // import { SiteSupport } from '@views/lib/getSiteSupport';
 import clsx from 'clsx';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import IconoirGitFork from '~icons/iconoir/git-fork';
 import CalendarIcon from '~icons/material-symbols/calendar-month';
-// import { ExampleCourse } from 'src/stories/components/ConflictsWithWarning.stories';
-import DeleteForeverIcon from '~icons/material-symbols/delete-forever';
 
 // import { ExampleCourse } from 'src/stories/components/ConflictsWithWarning.stories';;
 import FileUpload from '../common/FileUpload';
@@ -48,12 +46,11 @@ const gitHubStatsService = new GitHubStatsService();
 const includeMergedPRs = false;
 
 /**
- * Opens the calendar page in a new tab.
- * @returns A promise that resolves when the options page is opened.
+ * Opens the calendar page.
+ * @returns A promise that resolves when the calendar page is opened.
  */
 const handleOpenCalendar = async (): Promise<void> => {
-    const url = chrome.runtime.getURL('/calendar.html');
-    await openTabFromContentScript(url);
+    await background.switchToCalendarTab({});
 };
 
 /**

--- a/src/views/components/settings/Settings.tsx
+++ b/src/views/components/settings/Settings.tsx
@@ -46,14 +46,6 @@ const gitHubStatsService = new GitHubStatsService();
 const includeMergedPRs = false;
 
 /**
- * Opens the calendar page.
- * @returns A promise that resolves when the calendar page is opened.
- */
-const handleOpenCalendar = async (): Promise<void> => {
-    await background.switchToCalendarTab({});
-};
-
-/**
  * Custom hook for enabling developer mode.
  *
  * @param targetCount - The target count to activate developer mode.
@@ -284,7 +276,12 @@ export default function Settings(): JSX.Element {
                             v{manifest.version} - {process.env.NODE_ENV}
                         </Text>
                     </Button>
-                    <Button variant='filled' icon={CalendarIcon} color='ut-burntorange' onClick={handleOpenCalendar}>
+                    <Button
+                        variant='filled'
+                        icon={CalendarIcon}
+                        color='ut-burntorange'
+                        onClick={() => background.switchToCalendarTab({})}
+                    >
                         Calendar
                     </Button>
                 </div>

--- a/src/views/components/settings/Settings.tsx
+++ b/src/views/components/settings/Settings.tsx
@@ -3,7 +3,7 @@ import { addCourseByURL } from '@pages/background/lib/addCourseByURL';
 import { deleteAllSchedules } from '@pages/background/lib/deleteSchedule';
 import exportSchedule from '@pages/background/lib/exportSchedule';
 import importSchedule from '@pages/background/lib/importSchedule';
-import { Trash } from '@phosphor-icons/react';
+import { CalendarDots, Trash } from '@phosphor-icons/react';
 import { background } from '@shared/messages';
 import { initSettings, OptionsStore } from '@shared/storage/OptionsStore';
 import { UserScheduleStore } from '@shared/storage/UserScheduleStore';
@@ -28,7 +28,6 @@ import clsx from 'clsx';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import IconoirGitFork from '~icons/iconoir/git-fork';
-import CalendarIcon from '~icons/material-symbols/calendar-month';
 
 // import { ExampleCourse } from 'src/stories/components/ConflictsWithWarning.stories';;
 import FileUpload from '../common/FileUpload';
@@ -278,7 +277,7 @@ export default function Settings(): JSX.Element {
                     </Button>
                     <Button
                         variant='filled'
-                        icon={CalendarIcon}
+                        icon={CalendarDots}
                         color='ut-burntorange'
                         onClick={() => background.switchToCalendarTab({})}
                     >


### PR DESCRIPTION
This PR resolves issue #424.

### Adds a button to go to the Calendar page from the Settings page without opening the extension.
Additionally, I adjusted the settings page header to match the Figma (convert from ALL CAPS to Normal Case).

#### Before:
<img width="1440" alt="settings-page-before" src="https://github.com/user-attachments/assets/8d3f519a-9c8c-4030-8cee-b99f0b62c136">

#### After:
<img width="1439" alt="settings-page-after" src="https://github.com/user-attachments/assets/b31ad0ef-c5ba-4a79-9211-68c3344f2313">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/457)
<!-- Reviewable:end -->
