### PR TITLE
chore: migrate to new scss import syntax

### DIFF
--- a/src/views/components/common/ExtensionRoot/ExtensionRoot.module.scss
+++ b/src/views/components/common/ExtensionRoot/ExtensionRoot.module.scss
@@ -1,8 +1,9 @@
-@import 'src/views/styles/base.module.scss';
+@use 'sass:meta';
+@use 'src/views/styles/base.module.scss';
 
 @layer base {
     .extensionRoot {
-        @import 'tailwind-compat';
+        @include meta.load-css('tailwind-compat');
     }
 
     span {

--- a/src/views/components/injected/AutoLoad/AutoLoad.module.scss
+++ b/src/views/components/injected/AutoLoad/AutoLoad.module.scss
@@ -1,4 +1,4 @@
-@import 'src/views/styles/base.module.scss';
+@use 'src/views/styles/base.module.scss';
 
 .autoLoad {
     display: flex;


### PR DESCRIPTION
gets rid of some of the annoying `pnpm build` warning

https://sass-lang.com/documentation/breaking-changes/import/
https://sass-lang.com/documentation/at-rules/use/
https://sass-lang.com/documentation/at-rules/mixin/

https://tinytip.co/tips/scss-load-css/

after:
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/74fad94f-ca56-4498-8413-1d115a6dc93b" />

before:
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/bb2b5b7d-ed82-446c-8953-5b507412255e" />

Co-authored-by: Long Phan <75595656+Wizardbacon13@users.noreply.github.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/478)
<!-- Reviewable:end -->
