### PR TITLE
feat(ui): change red text when instructor not found

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -255,8 +255,8 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                         <div className='mt-3 flex flex-wrap content-center items-center self-stretch justify-center gap-3 text-center'>
                             <Text variant='small' className='text-theme-red'>
                                 We couldn&apos;t find instructor-specific grades
-                                {semester !== 'Aggregate' && ` for ${semester.replace(/(\d{2})(\d{2})$/, '&apos;$2')}`},
-                                so here are the grades for all {course.department} {course.number} sections.
+                                {semester !== 'Aggregate' && ` for ${semester.replace(/(\d{2})(\d{2})$/, "'$2")}`}, so
+                                here are the grades for all {course.department} {course.number} sections.
                             </Text>
                         </div>
                     )}

--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -254,9 +254,8 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                     {distributions[semester] && !distributions[semester]!.instructorIncluded && (
                         <div className='mt-3 flex flex-wrap content-center items-center self-stretch justify-center gap-3 text-center'>
                             <Text variant='small' className='text-theme-red'>
-                                We couldn&apos;t find{' '}
-                                {semester !== 'Aggregate' && ` ${semester.replace(/(\d{2})(\d{2})$/, "'$2")}`} grades
-                                for this instructor, so here are the grades for all {course.department} {course.number}{' '}
+                                We couldn&apos;t find {semester !== 'Aggregate' && ` ${semester}`} grades for this
+                                instructor, so here are the grades for all {course.department} {course.number}H
                                 sections.
                             </Text>
                         </div>

--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -255,7 +255,7 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                         <div className='mt-3 flex flex-wrap content-center items-center self-stretch justify-center gap-3 text-center'>
                             <Text variant='small' className='text-theme-red'>
                                 We couldn&apos;t find {semester !== 'Aggregate' && ` ${semester}`} grades for this
-                                instructor, so here are the grades for all {course.department} {course.number}H
+                                instructor, so here are the grades for all {course.department} {course.number}
                                 sections.
                             </Text>
                         </div>

--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -252,10 +252,11 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                         </Link>
                     </div>
                     {distributions[semester] && !distributions[semester]!.instructorIncluded && (
-                        <div className='mt-3 flex flex-wrap content-center items-center self-stretch justify-center gap-3'>
-                            <Text variant='mini' className='text-theme-red italic!'>
-                                Instructor-specific data is not available for this course
-                                {semester !== 'Aggregate' && ` for ${semester}`}, showing course-wide data instead
+                        <div className='mt-3 flex flex-wrap content-center items-center self-stretch justify-center gap-3 text-center'>
+                            <Text variant='small' className='text-theme-red'>
+                                We couldn&apos;t find instructor-specific grades
+                                {semester !== 'Aggregate' && ` for ${semester.replace(/(\d{2})(\d{2})$/, '&apos;$2')}`},
+                                so here are the grades for all {course.department} {course.number} sections.
                             </Text>
                         </div>
                     )}

--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -255,8 +255,7 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                         <div className='mt-3 flex flex-wrap content-center items-center self-stretch justify-center gap-3 text-center'>
                             <Text variant='small' className='text-theme-red'>
                                 We couldn&apos;t find {semester !== 'Aggregate' && ` ${semester}`} grades for this
-                                instructor, so here are the grades for all {course.department} {course.number}
-                                sections.
+                                instructor, so here are the grades for all {course.department} {course.number} sections.
                             </Text>
                         </div>
                     )}

--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -254,9 +254,10 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                     {distributions[semester] && !distributions[semester]!.instructorIncluded && (
                         <div className='mt-3 flex flex-wrap content-center items-center self-stretch justify-center gap-3 text-center'>
                             <Text variant='small' className='text-theme-red'>
-                                We couldn&apos;t find instructor-specific grades
-                                {semester !== 'Aggregate' && ` for ${semester.replace(/(\d{2})(\d{2})$/, "'$2")}`}, so
-                                here are the grades for all {course.department} {course.number} sections.
+                                We couldn&apos;t find{' '}
+                                {semester !== 'Aggregate' && ` ${semester.replace(/(\d{2})(\d{2})$/, "'$2")}`} grades
+                                for this instructor, so here are the grades for all {course.department} {course.number}{' '}
+                                sections.
                             </Text>
                         </div>
                     )}


### PR DESCRIPTION
Fixes #404.

Updated text when an instructor is not found, changed text size to small, and removed italics.

Before:
"Instructor-specific data is not available for this course, showing course-wide data instead" 
After:
"We couldn't find instructor-specific grades, so here are the grades for all (insert course number) sections."

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/483)
<!-- Reviewable:end -->
