### PR TITLE
feat(ui): redesign grade distribution tooltip

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -140,7 +140,7 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
             tickWidth: 1,
             tickLength: 10,
             tickColor: '#9CADB7',
-            crosshair: true,
+            crosshair: { color: "rgba(214, 210, 196, 0.25)" },
             lineColor: '#9CADB7',
         },
         yAxis: {
@@ -173,12 +173,26 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
         credits: { enabled: false },
         accessibility: { enabled: true },
         tooltip: {
-            headerFormat: '<span style="font-size:small; font-weight:bold">{point.key}</span><table>',
+            headerFormat:
+                '<span style="display:block; font-weight:700;">{point.key}</span>',
             pointFormat:
-                '<td style="color:{black};padding:0;font-size:small; font-weight:bold;"><b>{point.y:.0f} Students</b></td>',
-            footerFormat: '</table>',
+                '<span style="display:block; font-weight:500;">{point.y:.0f} Students</span>',
             shared: true,
             useHTML: true,
+            style: {
+                color: 'var(--Other-Colors-UTRP-Black, #1A2024)',
+                textAlign: 'center',
+                fontFamily: 'Roboto Flex, Roboto Flex Local',
+                fontSize: '0.88875rem',
+                lineHeight: 'normal',
+            },
+            backgroundColor: "white",
+            borderRadius: 4,
+            shadow: {
+                offsetX: 0,
+                offsetY: 1,
+                color: 'rgba(51, 63, 72, 0.30)',
+            },
         },
         plotOptions: {
             bar: { pointPadding: 0.2, borderWidth: 0 },

--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -140,7 +140,7 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
             tickWidth: 1,
             tickLength: 10,
             tickColor: '#9CADB7',
-            crosshair: { color: 'rgba(214, 210, 196, 0.25)' },
+            crosshair: { color: extendedColors.theme.offwhite2 },
             lineColor: '#9CADB7',
         },
         yAxis: {

--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -140,7 +140,7 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
             tickWidth: 1,
             tickLength: 10,
             tickColor: '#9CADB7',
-            crosshair: { color: "rgba(214, 210, 196, 0.25)" },
+            crosshair: { color: 'rgba(214, 210, 196, 0.25)' },
             lineColor: '#9CADB7',
         },
         yAxis: {
@@ -173,10 +173,8 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
         credits: { enabled: false },
         accessibility: { enabled: true },
         tooltip: {
-            headerFormat:
-                '<span style="display:block; font-weight:700;">{point.key}</span>',
-            pointFormat:
-                '<span style="display:block; font-weight:500;">{point.y:.0f} Students</span>',
+            headerFormat: '<span style="display:block; font-weight:700;">{point.key}</span>',
+            pointFormat: '<span style="display:block; font-weight:500;">{point.y:.0f} Students</span>',
             shared: true,
             useHTML: true,
             style: {
@@ -186,7 +184,7 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                 fontSize: '0.88875rem',
                 lineHeight: 'normal',
             },
-            backgroundColor: "white",
+            backgroundColor: 'white',
             borderRadius: 4,
             shadow: {
                 offsetX: 0,


### PR DESCRIPTION
This PR resolves issue #332.

### Redesigns the grade distribution tooltip to match the figma designs

#### Issues:
I followed the specifications in the issue #332 to match the design as much as possible. However, AFAIK, the Highcharts API doesn't support layered box shadows and there isn't a away to control the `blur` or `spread` properly. Therefore, I only applied the first box shadow as closely as possible.

#### Before:
<img width="716" alt="image" src="https://github.com/user-attachments/assets/27817847-a0b0-4cad-b316-ae18d5a3a754" />

#### After:
<img width="714" alt="image" src="https://github.com/user-attachments/assets/f628a69e-194b-4a86-869f-ba2424acd823" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/485)
<!-- Reviewable:end -->
