### PR TITLE
feat(ui): made top day labels sticky

### DIFF
--- a/src/views/components/calendar/Calendar.tsx
+++ b/src/views/components/calendar/Calendar.tsx
@@ -11,6 +11,7 @@ import { CalendarContext } from '@views/contexts/CalendarContext';
 import useCourseFromUrl from '@views/hooks/useCourseFromUrl';
 import { useFlattenedCourseSchedule } from '@views/hooks/useFlattenedCourseSchedule';
 import { MessageListener } from 'chrome-extension-toolkit';
+import Text from '@views/components/common/Text/Text';
 import React, { useEffect, useState } from 'react';
 
 import CalendarFooter from './CalendarFooter';
@@ -26,6 +27,8 @@ export default function Calendar(): JSX.Element {
 
     const [showPopup, setShowPopup] = useState<boolean>(course !== null);
     const [showSidebar, setShowSidebar] = useState<boolean>(true);
+
+    const daysOfWeek = ['MON', 'TUE', 'WED', 'THU', 'FRI'];
 
     useEffect(() => {
         const listener = new MessageListener<CalendarTabMessages>({
@@ -72,11 +75,32 @@ export default function Calendar(): JSX.Element {
                             <CalendarFooter />
                         </div>
                     )}
-                    <div className='h-full min-w-5xl flex flex-grow flex-col overflow-y-auto'>
-                        <div className='min-h-2xl flex-grow overflow-auto pl-2 pr-4 pt-6 screenshot:min-h-xl'>
-                            <CalendarGrid courseCells={courseCells} setCourse={setCourse} />
+                    <div className='h-full flex flex-grow flex-col pl-2'>
+                        <div className='min-w-5xl flex flex-col pr-7.5'>
+                            <div className='grid grid-cols-[auto_auto_repeat(5,1fr)] grid-rows-[auto] pt-6'>
+                                {/* Displaying day labels */}
+                                <div className='w-12 pr-1 border-b border-gray-300' />
+                                <div className='w-4 border-b border-r border-gray-300' />
+                                {daysOfWeek.map(day => (
+                                    <div className='h-4 flex items-end justify-center border-b border-r border-gray-300 pb-1.5'>
+                                        <Text
+                                            key={day}
+                                            variant='small'
+                                            className='text-center text-ut-burntorange'
+                                            as='div'
+                                        >
+                                            {day}
+                                        </Text>
+                                    </div>
+                                ))}
+                            </div>
                         </div>
-                        <CalendarBottomBar courseCells={courseCells} setCourse={setCourse} />
+                        <div className='min-w-5xl flex flex-grow flex-col overflow-y-auto pr-4'>
+                            <div className='min-h-xl h-full flex-grow overflow-auto screenshot:min-h-xl'>
+                                <CalendarGrid courseCells={courseCells} setCourse={setCourse} />
+                            </div>
+                            <CalendarBottomBar courseCells={courseCells} setCourse={setCourse} />
+                        </div>
                     </div>
                 </div>
 

--- a/src/views/components/calendar/CalendarGrid.tsx
+++ b/src/views/components/calendar/CalendarGrid.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 function CalendarHour({ hour }: { hour: number }) {
     return (
-        <div className='grid-row-span-2 pr-2'>
+        <div className='w-12 grid-row-span-2 pr-1'>
             <Text variant='small' className='inline-block w-full text-right -translate-y-2.25'>
                 {(hour % 12 === 0 ? 12 : hour % 12) + (hour < 12 ? ' AM' : ' PM')}
             </Text>
@@ -60,11 +60,7 @@ export default function CalendarGrid({
             <div />
             <div className='w-4 border-b border-r border-gray-300' />
             {daysOfWeek.map(day => (
-                <div className='h-4 flex items-end justify-center border-b border-r border-gray-300 pb-1.5'>
-                    <Text key={day} variant='small' className='text-center text-ut-burntorange' as='div'>
-                        {day}
-                    </Text>
-                </div>
+                <div className='h-4 flex items-end justify-center border-b border-r border-gray-300 pb-1.5'></div>
             ))}
             {[...Array(13).keys()].map(i => makeGridRow(i, 5))}
             <CalendarHour hour={21} />


### PR DESCRIPTION
WIP for #357, would appreciate any help thanks!

Currently I have it such that the top bar with the day labels is sticky when the window height is small enough, but I have two main problems:

- **UI**: I'm not really sure how to change the UI to allow for the sticky header, as the first time, 8 AM, can no longer be on the first horizontal line with the day labels. The Google calendar example resolves this by putting a gmt-5 on the line and the time below it, so I have something similar (image below):

- **Padding issue:** Currently the padding is good when the scroll bar appears, but if the window is fullscreened (no scroll) then the padding for the days and the times is messed up. Image also provided below

- **Units**: I had to put a decent amount of "arbitrary" paddings to actually line up the two sections, i.e. pr-7.5 for the top bar. Just wanted some feedback on some of the unit choices, whether they align with the figma/design principles, etc.

Before:
![image](https://github.com/user-attachments/assets/bea06c11-69d5-45a7-a1d7-2224937b520f)

After (note the 8 AM line change):
![image](https://github.com/user-attachments/assets/660d4410-d531-4a27-9aa2-a148bb8776cc)

Padding issue image when scrollbar is not present (fullscreen):
![image](https://github.com/user-attachments/assets/904d5c0b-963c-4e64-874a-2f109f0fe879)
