### PR TITLE
chore(cal): update course schedule links for fall and summer 2025

### DIFF
--- a/src/views/components/calendar/ResourceLinks.tsx
+++ b/src/views/components/calendar/ResourceLinks.tsx
@@ -15,6 +15,14 @@ interface LinkItem {
 
 const links: LinkItem[] = [
     {
+        text: "Fall '25 Course Schedule",
+        url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20259/',
+    },
+    {
+        text: "Summer '25 Course Schedule",
+        url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20256/',
+    },
+    {
         text: "Spring '25 Course Schedule",
         url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20252/',
     },
@@ -26,10 +34,6 @@ const links: LinkItem[] = [
         text: 'My Degree Audit (IDA)',
         url: 'https://utdirect.utexas.edu/apps/degree/audits/',
     },
-    // {
-    //     text: "Summer '24 Course Schedule",
-    //     url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20246/',
-    // },
     // {
     //     text: "'24-'25 Academic Calendar",
     //     url: 'https://registrar.utexas.edu/calendars/24-25',


### PR DESCRIPTION
This change ensures that people can easily get to the Summer and Fall '25 course catalogs when they release (typically, first week of March).

These links follow the URL pattern that UT has been using for years.

Now
<img width="302" alt="image" src="https://github.com/user-attachments/assets/ef152df9-932d-4444-9a98-2fb016e2a01c" />

Previously
<img width="303" alt="image" src="https://github.com/user-attachments/assets/76dd77ed-725e-469e-b300-372fd3512996" />

Going to keep Spring '25 there until the end of the semester.

Eventually, we'll want this to be automated based on the dates.

The screen looks like this before the course catalogs get released. I thought about showing a warning before this page opens, but I think it does a pretty good job of saying "is not currently available".

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a895accc-3488-4e90-8cb8-45d5d73e822c" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/534)
<!-- Reviewable:end -->
