### PR TITLE
fix: ics calendar export dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
         "prepare": "husky"
     },
     "dependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@date-fns/utc": "^2.1.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -40,10 +42,12 @@
         "chrome-extension-toolkit": "^0.0.54",
         "clsx": "^2.1.1",
         "conventional-changelog": "^6.0.0",
+        "date-fns": "^4.1.0",
         "highcharts": "^11.4.8",
         "highcharts-react-official": "^3.2.1",
         "html-to-image": "^1.11.13",
         "husky": "^9.1.7",
+        "ics": "^3.8.1",
         "kc-dabr-wasm": "^0.1.2",
         "nanoid": "^5.1.2",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     },
     "dependencies": {
         "@date-fns/tz": "^1.2.0",
-        "@date-fns/utc": "^2.1.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -47,7 +46,6 @@
         "highcharts-react-official": "^3.2.1",
         "html-to-image": "^1.11.13",
         "husky": "^9.1.7",
-        "ics": "^3.8.1",
         "kc-dabr-wasm": "^0.1.2",
         "nanoid": "^5.1.2",
         "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,6 @@ importers:
       '@date-fns/tz':
         specifier: ^1.2.0
         version: 1.2.0
-      '@date-fns/utc':
-        specifier: ^2.1.0
-        version: 2.1.0
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -79,9 +76,6 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
-      ics:
-        specifier: ^3.8.1
-        version: 3.8.1
       kc-dabr-wasm:
         specifier: ^0.1.2
         version: 0.1.2
@@ -585,9 +579,6 @@ packages:
 
   '@date-fns/tz@1.2.0':
     resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
-
-  '@date-fns/utc@2.1.0':
-    resolution: {integrity: sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -4303,9 +4294,6 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  ics@3.8.1:
-    resolution: {integrity: sha512-UqQlfkajfhrS4pUGQfGIJMYz/Jsl/ob3LqcfEhUmLbwumg+ZNkU0/6S734Vsjq3/FYNpEcZVKodLBoe+zBM69g==}
-
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -5860,9 +5848,6 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  property-expr@2.0.6:
-    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
-
   property-information@5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
 
@@ -6113,9 +6098,6 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
-  runes2@1.1.4:
-    resolution: {integrity: sha512-LNPnEDPOOU4ehF71m5JoQyzT2yxwD6ZreFJ7MxZUAoMKNMY1XrAo60H1CUoX5ncSm0rIuKlqn9JZNRrRkNou2g==}
 
   rxjs@7.5.7:
     resolution: {integrity: sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==}
@@ -6568,9 +6550,6 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
-  tiny-case@1.0.3:
-    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
-
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -6603,9 +6582,6 @@ packages:
   to-through@3.0.0:
     resolution: {integrity: sha512-y8MN937s/HVhEoBU1SxfHC+wxCHkV1a9gW8eAdTadYh/bGyesZIVcbjI+mSpFbSVwQici/XjBjuUyri1dnXwBw==}
     engines: {node: '>=10.13.0'}
-
-  toposort@2.0.2:
-    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -7098,9 +7074,6 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
-  yup@1.6.1:
-    resolution: {integrity: sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==}
-
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -7405,8 +7378,6 @@ snapshots:
       - supports-color
 
   '@date-fns/tz@1.2.0': {}
-
-  '@date-fns/utc@2.1.0': {}
 
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
@@ -11583,12 +11554,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ics@3.8.1:
-    dependencies:
-      nanoid: 3.3.8
-      runes2: 1.1.4
-      yup: 1.6.1
-
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -13200,8 +13165,6 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  property-expr@2.0.6: {}
-
   property-information@5.6.0:
     dependencies:
       xtend: 4.0.2
@@ -13543,8 +13506,6 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  runes2@1.1.4: {}
 
   rxjs@7.5.7:
     dependencies:
@@ -14080,8 +14041,6 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
-  tiny-case@1.0.3: {}
-
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -14106,8 +14065,6 @@ snapshots:
   to-through@3.0.0:
     dependencies:
       streamx: 2.22.0
-
-  toposort@2.0.2: {}
 
   totalist@3.0.1: {}
 
@@ -14682,12 +14639,5 @@ snapshots:
   yocto-queue@1.1.1: {}
 
   yoctocolors@2.1.1: {}
-
-  yup@1.6.1:
-    dependencies:
-      property-expr: 2.0.6
-      tiny-case: 1.0.3
-      toposort: 2.0.2
-      type-fest: 2.19.0
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,16 +9,22 @@ overrides:
 
 patchedDependencies:
   '@crxjs/vite-plugin@2.0.0-beta.21':
-    hash: xq4uab3o3kbvv4gixvawl2aj5q
+    hash: 638b2575ead9e3df6bf5df962712f1fcbddf1d7ac61ce8dce0cfcc471d404a03
     path: patches/@crxjs__vite-plugin@2.0.0-beta.21.patch
   '@unocss/vite':
-    hash: 5ptgy7mbavmjf7zwexb7dph4ji
+    hash: 9e2d2732a6e057a2ca90fba199730f252d8b4db8631b2c6ee0854fce7771bc95
     path: patches/@unocss__vite.patch
 
 importers:
 
   .:
     dependencies:
+      '@date-fns/tz':
+        specifier: ^1.2.0
+        version: 1.2.0
+      '@date-fns/utc':
+        specifier: ^2.1.0
+        version: 2.1.0
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -45,7 +51,7 @@ importers:
         version: 8.55.0(react@18.3.1)
       '@unocss/vite':
         specifier: ^0.63.6
-        version: 0.63.6(patch_hash=5ptgy7mbavmjf7zwexb7dph4ji)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
+        version: 0.63.6(patch_hash=9e2d2732a6e057a2ca90fba199730f252d8b4db8631b2c6ee0854fce7771bc95)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
@@ -58,6 +64,9 @@ importers:
       conventional-changelog:
         specifier: ^6.0.0
         version: 6.0.0(conventional-commits-filter@5.0.0)
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       highcharts:
         specifier: ^11.4.8
         version: 11.4.8
@@ -70,6 +79,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      ics:
+        specifier: ^3.8.1
+        version: 3.8.1
       kc-dabr-wasm:
         specifier: ^0.1.2
         version: 0.1.2
@@ -118,7 +130,7 @@ importers:
         version: 19.5.0
       '@crxjs/vite-plugin':
         specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(patch_hash=xq4uab3o3kbvv4gixvawl2aj5q)
+        version: 2.0.0-beta.21(patch_hash=638b2575ead9e3df6bf5df962712f1fcbddf1d7ac61ce8dce0cfcc471d404a03)
       '@iconify-json/bi':
         specifier: ^1.2.2
         version: 1.2.2
@@ -570,6 +582,12 @@ packages:
 
   '@crxjs/vite-plugin@2.0.0-beta.21':
     resolution: {integrity: sha512-kSXgHHqCXASqJ8NmY94+KLGVwdtkJ0E7KsRQ+vbMpRliJ5ze0xnSk0l41p4txlUysmEoqaeo4Xb7rEFdcU2zjQ==}
+
+  '@date-fns/tz@1.2.0':
+    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
+
+  '@date-fns/utc@2.1.0':
+    resolution: {integrity: sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -3269,6 +3287,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -4281,6 +4302,9 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  ics@3.8.1:
+    resolution: {integrity: sha512-UqQlfkajfhrS4pUGQfGIJMYz/Jsl/ob3LqcfEhUmLbwumg+ZNkU0/6S734Vsjq3/FYNpEcZVKodLBoe+zBM69g==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -5836,6 +5860,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-expr@2.0.6:
+    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
+
   property-information@5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
 
@@ -6086,6 +6113,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  runes2@1.1.4:
+    resolution: {integrity: sha512-LNPnEDPOOU4ehF71m5JoQyzT2yxwD6ZreFJ7MxZUAoMKNMY1XrAo60H1CUoX5ncSm0rIuKlqn9JZNRrRkNou2g==}
 
   rxjs@7.5.7:
     resolution: {integrity: sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==}
@@ -6538,6 +6568,9 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
+  tiny-case@1.0.3:
+    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -6570,6 +6603,9 @@ packages:
   to-through@3.0.0:
     resolution: {integrity: sha512-y8MN937s/HVhEoBU1SxfHC+wxCHkV1a9gW8eAdTadYh/bGyesZIVcbjI+mSpFbSVwQici/XjBjuUyri1dnXwBw==}
     engines: {node: '>=10.13.0'}
+
+  toposort@2.0.2:
+    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -7062,6 +7098,9 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
+  yup@1.6.1:
+    resolution: {integrity: sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -7344,7 +7383,7 @@ snapshots:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.1.0
 
-  '@crxjs/vite-plugin@2.0.0-beta.21(patch_hash=xq4uab3o3kbvv4gixvawl2aj5q)':
+  '@crxjs/vite-plugin@2.0.0-beta.21(patch_hash=638b2575ead9e3df6bf5df962712f1fcbddf1d7ac61ce8dce0cfcc471d404a03)':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@webcomponents/custom-elements': 1.6.0
@@ -7364,6 +7403,10 @@ snapshots:
       rxjs: 7.5.7
     transitivePeerDependencies:
       - supports-color
+
+  '@date-fns/tz@1.2.0': {}
+
+  '@date-fns/utc@2.1.0': {}
 
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
@@ -9029,7 +9072,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.63.6
       '@unocss/reset': 0.63.6
-      '@unocss/vite': 0.63.6(patch_hash=5ptgy7mbavmjf7zwexb7dph4ji)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
+      '@unocss/vite': 0.63.6(patch_hash=9e2d2732a6e057a2ca90fba199730f252d8b4db8631b2c6ee0854fce7771bc95)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
     optionalDependencies:
       vite: 5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0)
     transitivePeerDependencies:
@@ -9182,7 +9225,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.63.6
 
-  '@unocss/vite@0.63.6(patch_hash=5ptgy7mbavmjf7zwexb7dph4ji)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))':
+  '@unocss/vite@0.63.6(patch_hash=9e2d2732a6e057a2ca90fba199730f252d8b4db8631b2c6ee0854fce7771bc95)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
@@ -10236,6 +10279,8 @@ snapshots:
       call-bound: 1.0.3
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@4.1.0: {}
 
   debug@2.6.9:
     dependencies:
@@ -11537,6 +11582,12 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  ics@3.8.1:
+    dependencies:
+      nanoid: 3.3.8
+      runes2: 1.1.4
+      yup: 1.6.1
 
   ieee754@1.2.1: {}
 
@@ -13149,6 +13200,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-expr@2.0.6: {}
+
   property-information@5.6.0:
     dependencies:
       xtend: 4.0.2
@@ -13490,6 +13543,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  runes2@1.1.4: {}
 
   rxjs@7.5.7:
     dependencies:
@@ -14025,6 +14080,8 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
+  tiny-case@1.0.3: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -14049,6 +14106,8 @@ snapshots:
   to-through@3.0.0:
     dependencies:
       streamx: 2.22.0
+
+  toposort@2.0.2: {}
 
   totalist@3.0.1: {}
 
@@ -14252,7 +14311,7 @@ snapshots:
       '@unocss/transformer-compile-class': 0.63.6
       '@unocss/transformer-directives': 0.63.6
       '@unocss/transformer-variant-group': 0.63.6
-      '@unocss/vite': 0.63.6(patch_hash=5ptgy7mbavmjf7zwexb7dph4ji)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
+      '@unocss/vite': 0.63.6(patch_hash=9e2d2732a6e057a2ca90fba199730f252d8b4db8631b2c6ee0854fce7771bc95)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
     optionalDependencies:
       vite: 5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0)
     transitivePeerDependencies:
@@ -14623,5 +14682,12 @@ snapshots:
   yocto-queue@1.1.1: {}
 
   yoctocolors@2.1.1: {}
+
+  yup@1.6.1:
+    dependencies:
+      property-expr: 2.0.6
+      tiny-case: 1.0.3
+      toposort: 2.0.2
+      type-fest: 2.19.0
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,10 @@ overrides:
 
 patchedDependencies:
   '@crxjs/vite-plugin@2.0.0-beta.21':
-    hash: 638b2575ead9e3df6bf5df962712f1fcbddf1d7ac61ce8dce0cfcc471d404a03
+    hash: xq4uab3o3kbvv4gixvawl2aj5q
     path: patches/@crxjs__vite-plugin@2.0.0-beta.21.patch
   '@unocss/vite':
-    hash: 9e2d2732a6e057a2ca90fba199730f252d8b4db8631b2c6ee0854fce7771bc95
+    hash: 5ptgy7mbavmjf7zwexb7dph4ji
     path: patches/@unocss__vite.patch
 
 importers:
@@ -48,7 +48,7 @@ importers:
         version: 8.55.0(react@18.3.1)
       '@unocss/vite':
         specifier: ^0.63.6
-        version: 0.63.6(patch_hash=9e2d2732a6e057a2ca90fba199730f252d8b4db8631b2c6ee0854fce7771bc95)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
+        version: 0.63.6(patch_hash=5ptgy7mbavmjf7zwexb7dph4ji)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
@@ -124,7 +124,7 @@ importers:
         version: 19.5.0
       '@crxjs/vite-plugin':
         specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(patch_hash=638b2575ead9e3df6bf5df962712f1fcbddf1d7ac61ce8dce0cfcc471d404a03)
+        version: 2.0.0-beta.21(patch_hash=xq4uab3o3kbvv4gixvawl2aj5q)
       '@iconify-json/bi':
         specifier: ^1.2.2
         version: 1.2.2
@@ -7356,7 +7356,7 @@ snapshots:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.1.0
 
-  '@crxjs/vite-plugin@2.0.0-beta.21(patch_hash=638b2575ead9e3df6bf5df962712f1fcbddf1d7ac61ce8dce0cfcc471d404a03)':
+  '@crxjs/vite-plugin@2.0.0-beta.21(patch_hash=xq4uab3o3kbvv4gixvawl2aj5q)':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@webcomponents/custom-elements': 1.6.0
@@ -9043,7 +9043,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.63.6
       '@unocss/reset': 0.63.6
-      '@unocss/vite': 0.63.6(patch_hash=9e2d2732a6e057a2ca90fba199730f252d8b4db8631b2c6ee0854fce7771bc95)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
+      '@unocss/vite': 0.63.6(patch_hash=5ptgy7mbavmjf7zwexb7dph4ji)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
     optionalDependencies:
       vite: 5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0)
     transitivePeerDependencies:
@@ -9196,7 +9196,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.63.6
 
-  '@unocss/vite@0.63.6(patch_hash=9e2d2732a6e057a2ca90fba199730f252d8b4db8631b2c6ee0854fce7771bc95)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))':
+  '@unocss/vite@0.63.6(patch_hash=5ptgy7mbavmjf7zwexb7dph4ji)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
@@ -14268,7 +14268,7 @@ snapshots:
       '@unocss/transformer-compile-class': 0.63.6
       '@unocss/transformer-directives': 0.63.6
       '@unocss/transformer-variant-group': 0.63.6
-      '@unocss/vite': 0.63.6(patch_hash=9e2d2732a6e057a2ca90fba199730f252d8b4db8631b2c6ee0854fce7771bc95)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
+      '@unocss/vite': 0.63.6(patch_hash=5ptgy7mbavmjf7zwexb7dph4ji)(rollup@4.34.8)(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0))
     optionalDependencies:
       vite: 5.4.14(@types/node@22.13.5)(sass@1.85.1)(terser@5.39.0)
     transitivePeerDependencies:

--- a/src/shared/util/string.ts
+++ b/src/shared/util/string.ts
@@ -48,3 +48,22 @@ export const ellipsify = (input: string, chars: number): string => {
     }
     return ellipisifed;
 };
+
+/**
+ *  Stringifies a list of items in English format.
+ *
+ * @param items - The list of items to stringify.
+ * @returns A string representation of the list in English format.
+ * @example
+ * englishStringifyList([]) // ''
+ * englishStringifyList(['Alice']) // 'Alice'
+ * englishStringifyList(['Alice', 'Bob']) // 'Alice and Bob'
+ * englishStringifyList(['Alice', 'Bob', 'Charlie']) // 'Alice, Bob, and Charlie'
+ */
+export const englishStringifyList = (items: readonly string[]): string => {
+    if (items.length === 0) return '';
+    if (items.length === 1) return items[0]!;
+    if (items.length === 2) return `${items[0]} and ${items[1]}`;
+
+    return `${items.slice(0, -1).join(', ')}, and ${items.at(-1)}`;
+};

--- a/src/shared/util/tests/string.test.ts
+++ b/src/shared/util/tests/string.test.ts
@@ -1,4 +1,4 @@
-import { capitalize, capitalizeFirstLetter, ellipsify } from '@shared/util/string';
+import { capitalize, capitalizeFirstLetter, ellipsify, englishStringifyList } from '@shared/util/string';
 import { describe, expect, it } from 'vitest';
 
 // TODO: Fix `string.ts` and `string.test.ts` to make the tests pass
@@ -52,5 +52,51 @@ describe('ellipsify', () => {
 
         // Test case 4: Input string is empty
         expect(ellipsify('', 5)).toBe('');
+    });
+});
+
+describe('englishStringifyList', () => {
+    it('should handle an empty array', () => {
+        const data = [] satisfies string[];
+        const result = englishStringifyList(data);
+        const expected = '';
+        expect(result).toBe(expected);
+    });
+
+    it('should handle 1 element', () => {
+        const data = ['Alice'] satisfies string[];
+        const result = englishStringifyList(data);
+        const expected = 'Alice';
+        expect(result).toBe(expected);
+    });
+
+    it('should handle 2 elements', () => {
+        const data = ['Alice', 'Bob'] satisfies string[];
+        const result = englishStringifyList(data);
+        const expected = 'Alice and Bob';
+        expect(result).toBe(expected);
+    });
+
+    it('should handle 3 elements', () => {
+        const data = ['Alice', 'Bob', 'Charlie'] satisfies string[];
+        const result = englishStringifyList(data);
+        const expected = 'Alice, Bob, and Charlie';
+        expect(result).toBe(expected);
+    });
+
+    it('should handle n elements', () => {
+        const testcases = [
+            { data: [], expected: '' },
+            { data: ['foo'], expected: 'foo' },
+            { data: ['foo', 'bar'], expected: 'foo and bar' },
+            { data: ['foo', 'bar', 'baz'], expected: 'foo, bar, and baz' },
+            { data: ['a', 'b', 'c', 'd'], expected: 'a, b, c, and d' },
+            { data: 'abcdefghijk'.split(''), expected: 'a, b, c, d, e, f, g, h, i, j, and k' },
+        ] satisfies { data: string[]; expected: string }[];
+
+        for (const { data, expected } of testcases) {
+            const result = englishStringifyList(data);
+            expect(result).toBe(expected);
+        }
     });
 });

--- a/src/stories/injected/mocked.ts
+++ b/src/stories/injected/mocked.ts
@@ -174,3 +174,137 @@ export const mikeScottCS314Schedule: UserSchedule = new UserSchedule({
     hours: 3,
     updatedAt: Date.now(),
 });
+
+export const multiMeetingMultiInstructorCourse: Course = new Course({
+    colors: {
+        primaryColor: '#ef4444',
+        secondaryColor: '#991b1b',
+    },
+    core: [],
+    courseName: '44-REPORTING TEXAS',
+    creditHours: 3,
+    department: 'J',
+    description: [
+        "Contemporary social, professional, and intellectual concerns with the practice of journalism. Students work as online reporters, photographers, and editors for the School of Journalism's Reporting Texas Web site.",
+        'Prerequisite: Graduate standing; additional prerequisites vary with the topic.',
+        'Designed to accommodate 35 or fewer students. Course number may be repeated for credit when the topics vary.',
+    ],
+    flags: [],
+    fullName: 'J 395 44-REPORTING TEXAS',
+    instructionMode: 'In Person',
+    instructors: [
+        {
+            firstName: 'JOHN',
+            fullName: 'SCHWARTZ, JOHN R',
+            lastName: 'SCHWARTZ',
+            middleInitial: 'R',
+        },
+        {
+            firstName: 'JOHN',
+            fullName: 'BRIDGES, JOHN A III',
+            lastName: 'BRIDGES',
+            middleInitial: 'A',
+        },
+    ],
+    isReserved: true,
+    number: '395',
+    schedule: {
+        meetings: [
+            {
+                days: ['Tuesday', 'Thursday'],
+                endTime: 660,
+                location: {
+                    building: 'CMA',
+                    room: '6.146',
+                },
+                startTime: 570,
+            },
+            {
+                days: ['Friday'],
+                endTime: 960,
+                location: {
+                    building: 'DMC',
+                    room: '3.208',
+                },
+                startTime: 780,
+            },
+        ],
+    },
+    scrapedAt: 1742491957535,
+    semester: {
+        code: '20259',
+        season: 'Fall',
+        year: 2025,
+    },
+    status: 'OPEN',
+    uniqueId: 10335,
+    url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20259/10335/',
+});
+
+export const multiMeetingMultiInstructorSchedule: UserSchedule = new UserSchedule({
+    courses: [multiMeetingMultiInstructorCourse],
+    id: 'mmmis',
+    name: 'Multi Meeting Multi Instructor Schedule',
+    hours: 3,
+    updatedAt: Date.now(),
+});
+
+export const chatterjeeCS429Course: Course = new Course({
+    colors: {
+        primaryColor: '#0284c7',
+        secondaryColor: '#0c4a6e',
+    },
+    core: [],
+    courseName: 'COMP ORGANIZATN AND ARCH',
+    creditHours: 4,
+    department: 'C S',
+    description: [
+        'Restricted to computer science majors.',
+        'An introduction to low-level computer design ranging from the basics of digital design to the hardware/software interface for application programs. Includes basic systems principles of pipelining and caching, and requires writing and understanding programs at multiple levels.',
+        'Computer Science 429 and 429H may not both be counted.',
+        'Prerequisite: The following courses with a grade of at least C-: Computer Science 311 or 311H; and Computer Science 314 or 314H.',
+    ],
+    flags: [],
+    fullName: 'C S 429 COMP ORGANIZATN AND ARCH',
+    instructionMode: 'In Person',
+    instructors: [
+        {
+            firstName: 'SIDDHARTHA',
+            fullName: 'CHATTERJEE, SIDDHARTHA',
+            lastName: 'CHATTERJEE',
+        },
+    ],
+    isReserved: true,
+    number: '429',
+    schedule: {
+        meetings: [
+            {
+                days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday'],
+                endTime: 1020,
+                location: {
+                    building: 'UTC',
+                    room: '3.102',
+                },
+                startTime: 960,
+            },
+            {
+                days: ['Friday'],
+                endTime: 660,
+                location: {
+                    building: 'GSB',
+                    room: '2.122',
+                },
+                startTime: 540,
+            },
+        ],
+    },
+    scrapedAt: 1742496630445,
+    semester: {
+        code: '20259',
+        season: 'Fall',
+        year: 2025,
+    },
+    status: 'OPEN',
+    uniqueId: 54795,
+    url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20259/54795/',
+});

--- a/src/views/components/calendar/academic-calendars.ts
+++ b/src/views/components/calendar/academic-calendars.ts
@@ -1,0 +1,135 @@
+type Digit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+type Year = `20${Digit}${Digit}`;
+type Month = `0${Exclude<Digit, 0>}` | `1${'0' | '1' | '2'}`;
+type Day = `0${Exclude<Digit, 0>}` | `1${Digit}` | `2${Digit}` | `30` | `31`;
+type DateStr = `${Year}-${Month}-${Day}`;
+type SemesterDigit = 2 | 6 | 9;
+type SemesterIdentifier = `20${Digit}${Digit}${SemesterDigit}`;
+
+type AcademicCalendarSemester = {
+    year: number;
+    semester: 'Fall' | 'Spring' | 'Summer';
+    firstClassDate: DateStr;
+    lastClassDate: DateStr;
+    breakDates: (DateStr | [DateStr, DateStr])[];
+};
+
+export const academicCalendars = {
+    '20249': {
+        year: 2024,
+        semester: 'Fall',
+        firstClassDate: '2024-08-26',
+        lastClassDate: '2024-12-09',
+        breakDates: [
+            '2024-09-02', // Labor Day holiday
+            ['2024-11-25', '2024-11-30'], // Fall break / Thanksgiving
+        ],
+    },
+    '20252': {
+        year: 2025,
+        semester: 'Spring',
+        firstClassDate: '2025-01-13',
+        lastClassDate: '2025-04-28',
+        breakDates: [
+            '2025-01-20', // Martin Luther King, Jr. Day
+            ['2025-03-17', '2025-03-22'], // Spring Break
+        ],
+    },
+    '20256': {
+        year: 2025,
+        semester: 'Summer',
+        firstClassDate: '2025-06-05',
+        lastClassDate: '2025-08-15',
+        breakDates: [
+            '2025-06-19', // Juneteenth holiday
+            '2025-07-04', // Independence Day holiday
+        ],
+    },
+    '20259': {
+        year: 2025,
+        semester: 'Fall',
+        firstClassDate: '2025-08-25',
+        lastClassDate: '2025-12-08',
+        breakDates: [
+            '2025-09-01', // Labor Day holiday
+            ['2025-11-24', '2025-11-29'], // Fall break / Thanksgiving
+        ],
+    },
+    '20262': {
+        year: 2026,
+        semester: 'Spring',
+        firstClassDate: '2026-01-12',
+        lastClassDate: '2026-04-27',
+        breakDates: [
+            '2026-01-19', // Martin Luther King, Jr. Day
+            ['2026-03-16', '2026-03-21'], // Spring Break
+        ],
+    },
+    '20266': {
+        year: 2026,
+        semester: 'Summer',
+        firstClassDate: '2026-06-04',
+        lastClassDate: '2026-08-14',
+        breakDates: [
+            '2026-06-19', // Juneteenth holiday
+            '2026-07-04', // Independence Day holiday
+        ],
+    },
+    '20269': {
+        year: 2026,
+        semester: 'Fall',
+        firstClassDate: '2026-08-24',
+        lastClassDate: '2026-12-07',
+        breakDates: [
+            '2026-09-07', // Labor Day holiday
+            ['2026-11-23', '2026-11-28'], // Fall break / Thanksgiving
+        ],
+    },
+    '20272': {
+        year: 2027,
+        semester: 'Spring',
+        firstClassDate: '2027-01-11',
+        lastClassDate: '2027-04-26',
+        breakDates: [
+            '2027-01-18', // Martin Luther King, Jr. Day
+            ['2027-03-15', '2027-03-20'], // Spring Break
+        ],
+    },
+    '20276': {
+        year: 2027,
+        semester: 'Summer',
+        firstClassDate: '2027-06-03',
+        lastClassDate: '2027-08-13',
+        breakDates: [
+            '2027-07-04', // Independence Day holiday
+        ],
+    },
+    '20279': {
+        year: 2027,
+        semester: 'Fall',
+        firstClassDate: '2027-08-23',
+        lastClassDate: '2027-12-06',
+        breakDates: [
+            '2027-09-06', // Labor Day holiday
+            ['2027-11-22', '2027-11-27'], // Fall break / Thanksgiving
+        ],
+    },
+    '20282': {
+        year: 2028,
+        semester: 'Spring',
+        firstClassDate: '2028-01-18',
+        lastClassDate: '2028-05-01',
+        breakDates: [
+            ['2028-03-13', '2028-03-18'], // Spring Break
+        ],
+    },
+    '20286': {
+        year: 2028,
+        semester: 'Summer',
+        firstClassDate: '2028-06-08',
+        lastClassDate: '2028-08-18',
+        breakDates: [
+            '2028-07-04', // Independence Day holiday
+        ],
+    },
+} as const satisfies Partial<Record<SemesterIdentifier, AcademicCalendarSemester>>;

--- a/src/views/components/calendar/academic-calendars.ts
+++ b/src/views/components/calendar/academic-calendars.ts
@@ -1,7 +1,7 @@
 type Digit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 type Year = `20${Digit}${Digit}`;
 type Month = `0${Exclude<Digit, 0>}` | `1${'0' | '1' | '2'}`;
-type Day = `0${Exclude<Digit, 0>}` | `1${Digit}` | `2${Digit}` | `30` | `31`;
+type Day = `0${Exclude<Digit, 0>}` | `${1 | 2}${Digit}` | '30' | '31';
 type DateStr = `${Year}-${Month}-${Day}`;
 type SemesterDigit = 2 | 6 | 9;
 type SemesterIdentifier = `20${Digit}${Digit}${SemesterDigit}`;

--- a/src/views/components/calendar/academic-calendars.ts
+++ b/src/views/components/calendar/academic-calendars.ts
@@ -14,7 +14,72 @@ type AcademicCalendarSemester = {
     breakDates: (DateStr | [DateStr, DateStr])[];
 };
 
+/**
+ * UT Austin's academic calendars, split by semester.
+ *
+ * See https://registrar.utexas.edu/calendars for future years.
+ */
 export const academicCalendars = {
+    '20229': {
+        year: 2022,
+        semester: 'Fall',
+        firstClassDate: '2022-08-22',
+        lastClassDate: '2022-12-05',
+        breakDates: [
+            '2022-09-05', // Labor Day holiday
+            ['2022-11-21', '2022-11-26'], // Fall break / Thanksgiving
+        ],
+    },
+    '20232': {
+        year: 2023,
+        semester: 'Spring',
+        firstClassDate: '2023-01-09',
+        lastClassDate: '2023-04-24',
+        breakDates: [
+            '2023-01-16', // Martin Luther King, Jr. Day
+            ['2023-03-13', '2023-03-18'], // Spring Break
+        ],
+    },
+    '20236': {
+        year: 2023,
+        semester: 'Summer',
+        firstClassDate: '2023-06-01',
+        lastClassDate: '2023-08-11',
+        breakDates: [
+            '2023-06-19', // Juneteenth holiday
+            '2023-07-04', // Independence Day holiday
+        ],
+    },
+    '20239': {
+        year: 2023,
+        semester: 'Fall',
+        firstClassDate: '2023-08-21',
+        lastClassDate: '2023-12-04',
+        breakDates: [
+            '2023-09-04', // Labor Day holiday
+            ['2023-11-20', '2023-11-25'], // Fall break / Thanksgiving
+        ],
+    },
+    '20242': {
+        year: 2024,
+        semester: 'Spring',
+        firstClassDate: '2024-01-16',
+        lastClassDate: '2024-04-29',
+        breakDates: [
+            '2024-01-15', // Martin Luther King, Jr. Day
+            ['2024-03-11', '2024-03-16'], // Spring Break
+        ],
+    },
+    '20246': {
+        year: 2024,
+        semester: 'Summer',
+        firstClassDate: '2024-06-06',
+        lastClassDate: '2024-08-16',
+        breakDates: [
+            '2024-06-19', // Juneteenth holiday
+            '2024-07-04', // Independence Day holiday
+        ],
+    },
     '20249': {
         year: 2024,
         semester: 'Fall',

--- a/src/views/components/calendar/utils.test.ts
+++ b/src/views/components/calendar/utils.test.ts
@@ -8,7 +8,7 @@ import {
     multiMeetingMultiInstructorCourse,
     multiMeetingMultiInstructorSchedule,
 } from 'src/stories/injected/mocked';
-import { afterEach,describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
     allDatesInRanges,

--- a/src/views/components/calendar/utils.test.ts
+++ b/src/views/components/calendar/utils.test.ts
@@ -1,13 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { formatToHHMMSS, nextDayInclusive, englishStringifyList } from './utils';
-import { parse, getDate, format as formatDate, getDay, Day } from 'date-fns';
+import {
+    formatToHHMMSS,
+    nextDayInclusive,
+    englishStringifyList,
+    allDatesInRanges,
+    meetingToIcsString,
+    scheduleToIcsString,
+} from './utils';
+import { format as formatDate, parseISO } from 'date-fns';
 import { tz } from '@date-fns/tz';
+import {
+    chatterjeeCS429Course,
+    multiMeetingMultiInstructorCourse,
+    multiMeetingMultiInstructorSchedule,
+} from 'src/stories/injected/mocked';
+import { Serialized } from 'chrome-extension-toolkit';
 
 // Do all timezone calculations relative to UT's timezone
 const TIMEZONE = 'America/Chicago';
 const TZ = tz(TIMEZONE);
 
+// Date and datetime formats used by iCal
 const ISO_DATE_FORMAT = 'yyyy-MM-dd';
+const ISO_BASIC_DATETIME_FORMAT = "yyyyMMdd'T'HHmmss";
+
+/**
+ * Simulate serialized class instance, without the class's methods
+ *
+ * serde &lt;-- Serialize, Deserialize
+ */
+const serde = <T>(data: T) => JSON.parse(JSON.stringify(data)) as Serialized<T>;
 
 describe('formatToHHMMSS', () => {
     it('should format minutes to HHMMSS format', () => {
@@ -34,42 +56,42 @@ describe('formatToHHMMSS', () => {
 
 describe('nextDayInclusive', () => {
     it('should return the same date if the given day is the same as the target day', () => {
-        const date = parse('2024-01-01', ISO_DATE_FORMAT, new Date()); // Monday
+        const date = parseISO('2024-01-01', { in: TZ }); // Monday
         const day = 1; // Monday
         const result = nextDayInclusive(date, day);
         expect(formatDate(result, ISO_DATE_FORMAT)).toBe('2024-01-01');
     });
 
     it('should return the next day if the given day is not the same as the target day', () => {
-        const date = parse('2024-07-18', ISO_DATE_FORMAT, new Date()); // Thursday
+        const date = parseISO('2024-07-18', { in: TZ }); // Thursday
         const day = 2; // Tuesday
         const result = nextDayInclusive(date, day);
         expect(formatDate(result, ISO_DATE_FORMAT)).toBe('2024-07-23');
     });
 
     it('should wrap around years', () => {
-        const date = parse('2025-12-28', ISO_DATE_FORMAT, new Date()); // Sunday
+        const date = parseISO('2025-12-28', { in: TZ }); // Sunday
         const day = 5; // Friday
         const result = nextDayInclusive(date, day);
         expect(formatDate(result, ISO_DATE_FORMAT)).toBe('2026-01-02');
     });
 
     it('should handle leap day', () => {
-        const date = parse('2024-02-27', ISO_DATE_FORMAT, new Date()); // Tuesday
+        const date = parseISO('2024-02-27', { in: TZ }); // Tuesday
         const day = 4; // Thursday
         const result = nextDayInclusive(date, day);
         expect(formatDate(result, ISO_DATE_FORMAT)).toBe('2024-02-29');
     });
 
     it('should handle an entire week of inputs', () => {
-        const date = parse('2024-08-20', ISO_DATE_FORMAT, new Date()); // Tuesday
+        const date = parseISO('2024-08-20', { in: TZ }); // Tuesday
         const days = [0, 1, 2, 3, 4, 5, 6] as const;
         const results = days.map(day => nextDayInclusive(date, day));
         const resultsFormatted = results.map(result => formatDate(result, ISO_DATE_FORMAT));
         const expectedResults = [
             '2024-08-25',
             '2024-08-26',
-            '2024-08-20',
+            '2024-08-20', // Same date
             '2024-08-21',
             '2024-08-22',
             '2024-08-23',
@@ -79,5 +101,333 @@ describe('nextDayInclusive', () => {
         for (let i = 0; i < days.length; i++) {
             expect(resultsFormatted[i]).toBe(expectedResults[i]);
         }
+    });
+
+    it('should maintain hours/minutes/seconds', () => {
+        const date = parseISO('20250115T143021', { in: TZ }); // Wednesday
+        const days = [0, 1, 2, 3, 4, 5, 6] as const;
+        const results = days.map(day => nextDayInclusive(date, day));
+        const resultsFormatted = results.map(result => formatDate(result, ISO_BASIC_DATETIME_FORMAT));
+        const expectedResults = [
+            '20250119T143021',
+            '20250120T143021',
+            '20250121T143021',
+            '20250115T143021',
+            '20250116T143021',
+            '20250117T143021',
+            '20250118T143021',
+        ];
+
+        for (let i = 0; i < days.length; i++) {
+            expect(resultsFormatted[i]).toBe(expectedResults[i]);
+        }
+    });
+});
+
+describe('englishStringifyList', () => {
+    it('should handle an empty array', () => {
+        const data = [] satisfies string[];
+        const result = englishStringifyList(data);
+        const expected = '';
+        expect(result).toBe(expected);
+    });
+
+    it('should handle 1 element', () => {
+        const data = ['Alice'] satisfies string[];
+        const result = englishStringifyList(data);
+        const expected = 'Alice';
+        expect(result).toBe(expected);
+    });
+
+    it('should handle 2 elements', () => {
+        const data = ['Alice', 'Bob'] satisfies string[];
+        const result = englishStringifyList(data);
+        const expected = 'Alice and Bob';
+        expect(result).toBe(expected);
+    });
+
+    it('should handle 3 elements', () => {
+        const data = ['Alice', 'Bob', 'Charlie'] satisfies string[];
+        const result = englishStringifyList(data);
+        const expected = 'Alice, Bob, and Charlie';
+        expect(result).toBe(expected);
+    });
+
+    it('should handle n elements', () => {
+        const testcases = [
+            { data: [], expected: '' },
+            { data: ['foo'], expected: 'foo' },
+            { data: ['foo', 'bar'], expected: 'foo and bar' },
+            { data: ['foo', 'bar', 'baz'], expected: 'foo, bar, and baz' },
+            { data: ['a', 'b', 'c', 'd'], expected: 'a, b, c, and d' },
+            { data: 'abcdefghijk'.split(''), expected: 'a, b, c, d, e, f, g, h, i, j, and k' },
+        ] satisfies { data: string[]; expected: string }[];
+
+        for (const { data, expected } of testcases) {
+            const result = englishStringifyList(data);
+            expect(result).toBe(expected);
+        }
+    });
+});
+
+describe('allDatesInRanges', () => {
+    it('should handle empty array', () => {
+        const dateRanges = [] satisfies string[];
+        const result = allDatesInRanges(dateRanges);
+        const expected = [] satisfies Date[];
+        expect(result).toEqual(expected);
+    });
+
+    it('should handle a single date', () => {
+        const dateRanges = ['2025-03-14'] satisfies (string | [string, string])[];
+        const result = allDatesInRanges(dateRanges);
+        const expected = ['2025-03-14'].map(dateStr => parseISO(dateStr, { in: TZ })) satisfies Date[];
+        expect(result).toEqual(expected);
+    });
+
+    it('should handle a single date', () => {
+        const dateRanges = ['2025-03-14'] satisfies string[];
+        const result = allDatesInRanges(dateRanges);
+        const expected = ['2025-03-14'].map(dateStr => parseISO(dateStr, { in: TZ })) satisfies Date[];
+        expect(result).toEqual(expected);
+    });
+
+    it('should handle a single date range', () => {
+        const dateRanges = [['2025-03-14', '2025-03-19']] satisfies (string | [string, string])[];
+        const result = allDatesInRanges(dateRanges);
+        const expected = ['2025-03-14', '2025-03-15', '2025-03-16', '2025-03-17', '2025-03-18', '2025-03-19'].map(
+            dateStr => parseISO(dateStr, { in: TZ })
+        ) satisfies Date[];
+        expect(result).toEqual(expected);
+    });
+
+    it('should handle multiple dates/date ranges', () => {
+        const dateRanges = [
+            '2025-02-14',
+            ['2025-03-14', '2025-03-19'],
+            '2026-12-01',
+            ['2026-12-03', '2026-12-05'],
+        ] satisfies (string | [string, string])[];
+        const result = allDatesInRanges(dateRanges);
+        const expected = [
+            '2025-02-14', // '2025-02-14'
+            '2025-03-14', // ['2025-03-14', '2025-03-19']
+            '2025-03-15',
+            '2025-03-16',
+            '2025-03-17',
+            '2025-03-18',
+            '2025-03-19',
+            '2026-12-01', // '2026-12-01'
+            '2026-12-03', // ['2026-12-03', '2026-12-05'
+            '2026-12-04',
+            '2026-12-05',
+        ].map(dateStr => parseISO(dateStr, { in: TZ })) satisfies Date[];
+        expect(result).toEqual(expected);
+    });
+
+    it('should handle month-/year-spanning ranges', () => {
+        const dateRanges = [
+            ['2023-02-27', '2023-03-02'],
+            ['2023-12-27', '2024-01-03'],
+        ] satisfies (string | [string, string])[];
+        console.log(dateRanges);
+        const result = allDatesInRanges(dateRanges);
+        console.log(result);
+        const expected = [
+            '2023-02-27', // ['2023-02-27', '2023-03-2']
+            '2023-02-28',
+            '2023-03-01',
+            '2023-03-02',
+            '2023-12-27', // ['2023-12-27', '2024-01-3']
+            '2023-12-28',
+            '2023-12-29',
+            '2023-12-30',
+            '2023-12-31',
+            '2024-01-01',
+            '2024-01-02',
+            '2024-01-03',
+        ].map(dateStr => parseISO(dateStr, { in: TZ })) satisfies Date[];
+        expect(result).toEqual(expected);
+    });
+
+    it('should handle leap years', () => {
+        const dateRanges = [
+            ['2023-02-27', '2023-03-02'],
+            ['2024-02-27', '2024-03-02'],
+            ['2025-02-27', '2025-03-02'],
+        ] satisfies (string | [string, string])[];
+        const result = allDatesInRanges(dateRanges);
+        const expected = [
+            '2023-02-27', // ['2023-02-27', '2023-03-2']
+            '2023-02-28',
+            '2023-03-01',
+            '2023-03-02',
+            '2024-02-27', // ['2024-02-27', '2024-03-2']
+            '2024-02-28',
+            '2024-02-29',
+            '2024-03-01',
+            '2024-03-02',
+            '2025-02-27', // ['2025-02-27', '2025-03-2']
+            '2025-02-28',
+            '2025-03-01',
+            '2025-03-02',
+        ].map(dateStr => parseISO(dateStr, { in: TZ })) satisfies Date[];
+        expect(result).toEqual(expected);
+    });
+});
+
+describe('meetingToIcsString', () => {
+    it('should handle a one-day meeting with one instructor', () => {
+        const course = serde(multiMeetingMultiInstructorCourse);
+        course.instructors = course.instructors.slice(0, 1);
+        const meeting = course.schedule.meetings[1]!;
+        const result = meetingToIcsString(course, meeting);
+        const expected = (
+            `BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:20250829T130000
+            DTEND;TZID=America/Chicago:20250829T160000
+            RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
+            EXDATE;TZID=America/Chicago:20251128T130000
+            ` +
+            // Only skips one Thanksgiving break day
+            `SUMMARY:J 395 44-REPORTING TEXAS
+            LOCATION:DMC 3.208
+            DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz
+            END:VEVENT`
+        ).replaceAll(/^\s+/gm, '');
+        expect(result).toBe(expected);
+    });
+
+    it('should handle unique numbers below 5 digits', () => {
+        const course = serde(multiMeetingMultiInstructorCourse);
+        course.instructors = course.instructors.slice(0, 1);
+        course.uniqueId = 4269;
+        const meeting = course.schedule.meetings[1]!;
+        const result = meetingToIcsString(course, meeting);
+        const expected = `BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:20250829T130000
+            DTEND;TZID=America/Chicago:20250829T160000
+            RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
+            EXDATE;TZID=America/Chicago:20251128T130000
+            SUMMARY:J 395 44-REPORTING TEXAS
+            LOCATION:DMC 3.208
+            DESCRIPTION:Unique number: 04269\\nTaught by John Schwartz
+            END:VEVENT`.replaceAll(/^\s+/gm, '');
+        expect(result).toBe(expected);
+    });
+
+    it('should handle a one-day meeting with multiple instructors', () => {
+        const course = serde(multiMeetingMultiInstructorCourse);
+        const meeting = course.schedule.meetings[1]!;
+        const result = meetingToIcsString(course, meeting);
+        const expected = `BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:20250829T130000
+            DTEND;TZID=America/Chicago:20250829T160000
+            RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
+            EXDATE;TZID=America/Chicago:20251128T130000
+            SUMMARY:J 395 44-REPORTING TEXAS
+            LOCATION:DMC 3.208
+            DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
+            END:VEVENT`.replaceAll(/^\s+/gm, '');
+        expect(result).toBe(expected);
+    });
+
+    it('should handle a multi-day meeting with multiple instructors', () => {
+        const course = serde(multiMeetingMultiInstructorCourse);
+        const meeting = course.schedule.meetings[0]!;
+        const result = meetingToIcsString(course, meeting);
+        const expected = `BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:20250826T093000
+            DTEND;TZID=America/Chicago:20250826T110000
+            RRULE:FREQ=WEEKLY;BYDAY=TU,TH;UNTIL=20251209T060000Z
+            EXDATE;TZID=America/Chicago:20251125T093000,20251127T093000
+            SUMMARY:J 395 44-REPORTING TEXAS
+            LOCATION:CMA 6.146
+            DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
+            END:VEVENT`.replaceAll(/^\s+/gm, '');
+        expect(result).toBe(expected);
+    });
+});
+
+describe('scheduleToIcsString', () => {
+    it('should handle a single course with multiple meetings', () => {
+        const schedule = serde(multiMeetingMultiInstructorSchedule);
+        const result = scheduleToIcsString(schedule);
+        const expected = `BEGIN:VCALENDAR
+            VERSION:2.0
+            CALSCALE:GREGORIAN
+            X-WR-CALNAME:My Schedule
+            BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:20250826T093000
+            DTEND;TZID=America/Chicago:20250826T110000
+            RRULE:FREQ=WEEKLY;BYDAY=TU,TH;UNTIL=20251209T060000Z
+            EXDATE;TZID=America/Chicago:20251125T093000,20251127T093000
+            SUMMARY:J 395 44-REPORTING TEXAS
+            LOCATION:CMA 6.146
+            DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
+            END:VEVENT
+            BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:20250829T130000
+            DTEND;TZID=America/Chicago:20250829T160000
+            RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
+            EXDATE;TZID=America/Chicago:20251128T130000
+            SUMMARY:J 395 44-REPORTING TEXAS
+            LOCATION:DMC 3.208
+            DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
+            END:VEVENT
+            END:VCALENDAR`.replaceAll(/^\s+/gm, '');
+        expect(result).toBe(expected);
+    });
+
+    it('should handle a complex schedule', () => {
+        const schedule = serde(multiMeetingMultiInstructorSchedule);
+        schedule.courses.push(chatterjeeCS429Course);
+        const result = scheduleToIcsString(schedule);
+        const expected = (
+            `BEGIN:VCALENDAR
+            VERSION:2.0
+            CALSCALE:GREGORIAN
+            X-WR-CALNAME:My Schedule
+            BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:20250826T093000
+            DTEND;TZID=America/Chicago:20250826T110000
+            RRULE:FREQ=WEEKLY;BYDAY=TU,TH;UNTIL=20251209T060000Z
+            EXDATE;TZID=America/Chicago:20251125T093000,20251127T093000
+            SUMMARY:J 395 44-REPORTING TEXAS
+            LOCATION:CMA 6.146
+            DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
+            END:VEVENT
+            BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:20250829T130000
+            DTEND;TZID=America/Chicago:20250829T160000
+            RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
+            EXDATE;TZID=America/Chicago:20251128T130000
+            SUMMARY:J 395 44-REPORTING TEXAS
+            LOCATION:DMC 3.208
+            DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
+            END:VEVENT
+            BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:20250825T160000
+            DTEND;TZID=America/Chicago:20250825T170000
+            RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH;UNTIL=20251209T060000Z
+            ` +
+            // Skips Labor Day and only relevant days of Thanksgiving
+            `EXDATE;TZID=America/Chicago:20250901T160000,20251124T160000,20251125T160000,20251126T160000,20251127T160000
+            SUMMARY:C S 429 COMP ORGANIZATN AND ARCH
+            LOCATION:UTC 3.102
+            DESCRIPTION:Unique number: 54795\\nTaught by Siddhartha Chatterjee
+            END:VEVENT
+            BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:20250829T090000
+            DTEND;TZID=America/Chicago:20250829T110000
+            RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
+            EXDATE;TZID=America/Chicago:20251128T090000
+            SUMMARY:C S 429 COMP ORGANIZATN AND ARCH
+            LOCATION:GSB 2.122
+            DESCRIPTION:Unique number: 54795\\nTaught by Siddhartha Chatterjee
+            END:VEVENT
+            END:VCALENDAR`
+        ).replaceAll(/^\s+/gm, '');
+        expect(result).toBe(expected);
     });
 });

--- a/src/views/components/calendar/utils.test.ts
+++ b/src/views/components/calendar/utils.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import { formatToHHMMSS, nextDayInclusive, englishStringifyList } from './utils';
+import { parse, getDate, format as formatDate, getDay, Day } from 'date-fns';
+import { tz } from '@date-fns/tz';
 
-import { formatToHHMMSS } from './utils';
+// Do all timezone calculations relative to UT's timezone
+const TIMEZONE = 'America/Chicago';
+const TZ = tz(TIMEZONE);
+
+const ISO_DATE_FORMAT = 'yyyy-MM-dd';
 
 describe('formatToHHMMSS', () => {
     it('should format minutes to HHMMSS format', () => {
@@ -22,5 +29,55 @@ describe('formatToHHMMSS', () => {
         const expected = '000000';
         const result = formatToHHMMSS(minutes);
         expect(result).toBe(expected);
+    });
+});
+
+describe('nextDayInclusive', () => {
+    it('should return the same date if the given day is the same as the target day', () => {
+        const date = parse('2024-01-01', ISO_DATE_FORMAT, new Date()); // Monday
+        const day = 1; // Monday
+        const result = nextDayInclusive(date, day);
+        expect(formatDate(result, ISO_DATE_FORMAT)).toBe('2024-01-01');
+    });
+
+    it('should return the next day if the given day is not the same as the target day', () => {
+        const date = parse('2024-07-18', ISO_DATE_FORMAT, new Date()); // Thursday
+        const day = 2; // Tuesday
+        const result = nextDayInclusive(date, day);
+        expect(formatDate(result, ISO_DATE_FORMAT)).toBe('2024-07-23');
+    });
+
+    it('should wrap around years', () => {
+        const date = parse('2025-12-28', ISO_DATE_FORMAT, new Date()); // Sunday
+        const day = 5; // Friday
+        const result = nextDayInclusive(date, day);
+        expect(formatDate(result, ISO_DATE_FORMAT)).toBe('2026-01-02');
+    });
+
+    it('should handle leap day', () => {
+        const date = parse('2024-02-27', ISO_DATE_FORMAT, new Date()); // Tuesday
+        const day = 4; // Thursday
+        const result = nextDayInclusive(date, day);
+        expect(formatDate(result, ISO_DATE_FORMAT)).toBe('2024-02-29');
+    });
+
+    it('should handle an entire week of inputs', () => {
+        const date = parse('2024-08-20', ISO_DATE_FORMAT, new Date()); // Tuesday
+        const days = [0, 1, 2, 3, 4, 5, 6] as const;
+        const results = days.map(day => nextDayInclusive(date, day));
+        const resultsFormatted = results.map(result => formatDate(result, ISO_DATE_FORMAT));
+        const expectedResults = [
+            '2024-08-25',
+            '2024-08-26',
+            '2024-08-20',
+            '2024-08-21',
+            '2024-08-22',
+            '2024-08-23',
+            '2024-08-24',
+        ];
+
+        for (let i = 0; i < days.length; i++) {
+            expect(resultsFormatted[i]).toBe(expectedResults[i]);
+        }
     });
 });

--- a/src/views/components/calendar/utils.test.ts
+++ b/src/views/components/calendar/utils.test.ts
@@ -238,7 +238,7 @@ describe('meetingToIcsString', () => {
             EXDATE;TZID=America/Chicago:20251128T130000
             ` +
             // Only skips one Thanksgiving break day
-            `SUMMARY:J 395 44-REPORTING TEXAS
+            `SUMMARY:J 395 — 44-REPORTING TEXAS
             LOCATION:DMC 3.208
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz
             END:VEVENT`
@@ -257,7 +257,7 @@ describe('meetingToIcsString', () => {
             DTEND;TZID=America/Chicago:20250829T160000
             RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251128T130000
-            SUMMARY:J 395 44-REPORTING TEXAS
+            SUMMARY:J 395 — 44-REPORTING TEXAS
             LOCATION:DMC 3.208
             DESCRIPTION:Unique number: 04269\\nTaught by John Schwartz
             END:VEVENT`.replaceAll(/^\s+/gm, '');
@@ -273,7 +273,7 @@ describe('meetingToIcsString', () => {
             DTEND;TZID=America/Chicago:20250829T160000
             RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251128T130000
-            SUMMARY:J 395 44-REPORTING TEXAS
+            SUMMARY:J 395 — 44-REPORTING TEXAS
             LOCATION:DMC 3.208
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT`.replaceAll(/^\s+/gm, '');
@@ -305,7 +305,7 @@ describe('meetingToIcsString', () => {
             DTEND;TZID=America/Chicago:20250826T110000
             RRULE:FREQ=WEEKLY;BYDAY=TU,TH;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251125T093000,20251127T093000
-            SUMMARY:J 395 44-REPORTING TEXAS
+            SUMMARY:J 395 — 44-REPORTING TEXAS
             LOCATION:CMA 6.146
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT`.replaceAll(/^\s+/gm, '');
@@ -404,7 +404,7 @@ describe('scheduleToIcsString', () => {
             DTEND;TZID=America/Chicago:20250826T110000
             RRULE:FREQ=WEEKLY;BYDAY=TU,TH;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251125T093000,20251127T093000
-            SUMMARY:J 395 44-REPORTING TEXAS
+            SUMMARY:J 395 — 44-REPORTING TEXAS
             LOCATION:CMA 6.146
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT
@@ -413,7 +413,7 @@ describe('scheduleToIcsString', () => {
             DTEND;TZID=America/Chicago:20250829T160000
             RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251128T130000
-            SUMMARY:J 395 44-REPORTING TEXAS
+            SUMMARY:J 395 — 44-REPORTING TEXAS
             LOCATION:DMC 3.208
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT
@@ -435,7 +435,7 @@ describe('scheduleToIcsString', () => {
             DTEND;TZID=America/Chicago:20250826T110000
             RRULE:FREQ=WEEKLY;BYDAY=TU,TH;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251125T093000,20251127T093000
-            SUMMARY:J 395 44-REPORTING TEXAS
+            SUMMARY:J 395 — 44-REPORTING TEXAS
             LOCATION:CMA 6.146
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT
@@ -444,7 +444,7 @@ describe('scheduleToIcsString', () => {
             DTEND;TZID=America/Chicago:20250829T160000
             RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251128T130000
-            SUMMARY:J 395 44-REPORTING TEXAS
+            SUMMARY:J 395 — 44-REPORTING TEXAS
             LOCATION:DMC 3.208
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT
@@ -455,7 +455,7 @@ describe('scheduleToIcsString', () => {
             ` +
             // Skips Labor Day and only relevant days of Thanksgiving
             `EXDATE;TZID=America/Chicago:20250901T160000,20251124T160000,20251125T160000,20251126T160000,20251127T160000
-            SUMMARY:C S 429 COMP ORGANIZATN AND ARCH
+            SUMMARY:C S 429 — COMP ORGANIZATN AND ARCH
             LOCATION:UTC 3.102
             DESCRIPTION:Unique number: 54795\\nTaught by Siddhartha Chatterjee
             END:VEVENT
@@ -464,7 +464,7 @@ describe('scheduleToIcsString', () => {
             DTEND;TZID=America/Chicago:20250829T110000
             RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251128T090000
-            SUMMARY:C S 429 COMP ORGANIZATN AND ARCH
+            SUMMARY:C S 429 — COMP ORGANIZATN AND ARCH
             LOCATION:GSB 2.122
             DESCRIPTION:Unique number: 54795\\nTaught by Siddhartha Chatterjee
             END:VEVENT

--- a/src/views/components/calendar/utils.test.ts
+++ b/src/views/components/calendar/utils.test.ts
@@ -238,7 +238,7 @@ describe('meetingToIcsString', () => {
             EXDATE;TZID=America/Chicago:20251128T130000
             ` +
             // Only skips one Thanksgiving break day
-            `SUMMARY:J 395 — 44-REPORTING TEXAS
+            `SUMMARY:J 395 – 44-REPORTING TEXAS
             LOCATION:DMC 3.208
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz
             END:VEVENT`
@@ -257,7 +257,7 @@ describe('meetingToIcsString', () => {
             DTEND;TZID=America/Chicago:20250829T160000
             RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251128T130000
-            SUMMARY:J 395 — 44-REPORTING TEXAS
+            SUMMARY:J 395 – 44-REPORTING TEXAS
             LOCATION:DMC 3.208
             DESCRIPTION:Unique number: 04269\\nTaught by John Schwartz
             END:VEVENT`.replaceAll(/^\s+/gm, '');
@@ -273,7 +273,7 @@ describe('meetingToIcsString', () => {
             DTEND;TZID=America/Chicago:20250829T160000
             RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251128T130000
-            SUMMARY:J 395 — 44-REPORTING TEXAS
+            SUMMARY:J 395 – 44-REPORTING TEXAS
             LOCATION:DMC 3.208
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT`.replaceAll(/^\s+/gm, '');
@@ -305,7 +305,7 @@ describe('meetingToIcsString', () => {
             DTEND;TZID=America/Chicago:20250826T110000
             RRULE:FREQ=WEEKLY;BYDAY=TU,TH;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251125T093000,20251127T093000
-            SUMMARY:J 395 — 44-REPORTING TEXAS
+            SUMMARY:J 395 – 44-REPORTING TEXAS
             LOCATION:CMA 6.146
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT`.replaceAll(/^\s+/gm, '');
@@ -404,7 +404,7 @@ describe('scheduleToIcsString', () => {
             DTEND;TZID=America/Chicago:20250826T110000
             RRULE:FREQ=WEEKLY;BYDAY=TU,TH;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251125T093000,20251127T093000
-            SUMMARY:J 395 — 44-REPORTING TEXAS
+            SUMMARY:J 395 – 44-REPORTING TEXAS
             LOCATION:CMA 6.146
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT
@@ -413,7 +413,7 @@ describe('scheduleToIcsString', () => {
             DTEND;TZID=America/Chicago:20250829T160000
             RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251128T130000
-            SUMMARY:J 395 — 44-REPORTING TEXAS
+            SUMMARY:J 395 – 44-REPORTING TEXAS
             LOCATION:DMC 3.208
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT
@@ -435,7 +435,7 @@ describe('scheduleToIcsString', () => {
             DTEND;TZID=America/Chicago:20250826T110000
             RRULE:FREQ=WEEKLY;BYDAY=TU,TH;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251125T093000,20251127T093000
-            SUMMARY:J 395 — 44-REPORTING TEXAS
+            SUMMARY:J 395 – 44-REPORTING TEXAS
             LOCATION:CMA 6.146
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT
@@ -444,7 +444,7 @@ describe('scheduleToIcsString', () => {
             DTEND;TZID=America/Chicago:20250829T160000
             RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251128T130000
-            SUMMARY:J 395 — 44-REPORTING TEXAS
+            SUMMARY:J 395 – 44-REPORTING TEXAS
             LOCATION:DMC 3.208
             DESCRIPTION:Unique number: 10335\\nTaught by John Schwartz and John Bridges
             END:VEVENT
@@ -455,7 +455,7 @@ describe('scheduleToIcsString', () => {
             ` +
             // Skips Labor Day and only relevant days of Thanksgiving
             `EXDATE;TZID=America/Chicago:20250901T160000,20251124T160000,20251125T160000,20251126T160000,20251127T160000
-            SUMMARY:C S 429 — COMP ORGANIZATN AND ARCH
+            SUMMARY:C S 429 – COMP ORGANIZATN AND ARCH
             LOCATION:UTC 3.102
             DESCRIPTION:Unique number: 54795\\nTaught by Siddhartha Chatterjee
             END:VEVENT
@@ -464,7 +464,7 @@ describe('scheduleToIcsString', () => {
             DTEND;TZID=America/Chicago:20250829T110000
             RRULE:FREQ=WEEKLY;BYDAY=FR;UNTIL=20251209T060000Z
             EXDATE;TZID=America/Chicago:20251128T090000
-            SUMMARY:C S 429 — COMP ORGANIZATN AND ARCH
+            SUMMARY:C S 429 – COMP ORGANIZATN AND ARCH
             LOCATION:GSB 2.122
             DESCRIPTION:Unique number: 54795\\nTaught by Siddhartha Chatterjee
             END:VEVENT

--- a/src/views/components/calendar/utils.test.ts
+++ b/src/views/components/calendar/utils.test.ts
@@ -1,20 +1,21 @@
-import { describe, expect, it } from 'vitest';
-import {
-    formatToHHMMSS,
-    nextDayInclusive,
-    englishStringifyList,
-    allDatesInRanges,
-    meetingToIcsString,
-    scheduleToIcsString,
-} from './utils';
-import { format as formatDate, parseISO } from 'date-fns';
 import { tz } from '@date-fns/tz';
+import type { Serialized } from 'chrome-extension-toolkit';
+import { format as formatDate, parseISO } from 'date-fns';
 import {
     chatterjeeCS429Course,
     multiMeetingMultiInstructorCourse,
     multiMeetingMultiInstructorSchedule,
 } from 'src/stories/injected/mocked';
-import { Serialized } from 'chrome-extension-toolkit';
+import { describe, expect, it } from 'vitest';
+
+import {
+    allDatesInRanges,
+    englishStringifyList,
+    formatToHHMMSS,
+    meetingToIcsString,
+    nextDayInclusive,
+    scheduleToIcsString,
+} from './utils';
 
 // Do all timezone calculations relative to UT's timezone
 const TIMEZONE = 'America/Chicago';

--- a/src/views/components/calendar/utils.test.ts
+++ b/src/views/components/calendar/utils.test.ts
@@ -10,14 +10,7 @@ import {
 } from 'src/stories/injected/mocked';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-    allDatesInRanges,
-    englishStringifyList,
-    formatToHHMMSS,
-    meetingToIcsString,
-    nextDayInclusive,
-    scheduleToIcsString,
-} from './utils';
+import { allDatesInRanges, formatToHHMMSS, meetingToIcsString, nextDayInclusive, scheduleToIcsString } from './utils';
 
 // Do all timezone calculations relative to UT's timezone
 const TIMEZONE = 'America/Chicago';
@@ -123,52 +116,6 @@ describe('nextDayInclusive', () => {
 
         for (let i = 0; i < days.length; i++) {
             expect(resultsFormatted[i]).toBe(expectedResults[i]);
-        }
-    });
-});
-
-describe('englishStringifyList', () => {
-    it('should handle an empty array', () => {
-        const data = [] satisfies string[];
-        const result = englishStringifyList(data);
-        const expected = '';
-        expect(result).toBe(expected);
-    });
-
-    it('should handle 1 element', () => {
-        const data = ['Alice'] satisfies string[];
-        const result = englishStringifyList(data);
-        const expected = 'Alice';
-        expect(result).toBe(expected);
-    });
-
-    it('should handle 2 elements', () => {
-        const data = ['Alice', 'Bob'] satisfies string[];
-        const result = englishStringifyList(data);
-        const expected = 'Alice and Bob';
-        expect(result).toBe(expected);
-    });
-
-    it('should handle 3 elements', () => {
-        const data = ['Alice', 'Bob', 'Charlie'] satisfies string[];
-        const result = englishStringifyList(data);
-        const expected = 'Alice, Bob, and Charlie';
-        expect(result).toBe(expected);
-    });
-
-    it('should handle n elements', () => {
-        const testcases = [
-            { data: [], expected: '' },
-            { data: ['foo'], expected: 'foo' },
-            { data: ['foo', 'bar'], expected: 'foo and bar' },
-            { data: ['foo', 'bar', 'baz'], expected: 'foo, bar, and baz' },
-            { data: ['a', 'b', 'c', 'd'], expected: 'a, b, c, and d' },
-            { data: 'abcdefghijk'.split(''), expected: 'a, b, c, d, e, f, g, h, i, j, and k' },
-        ] satisfies { data: string[]; expected: string }[];
-
-        for (const { data, expected } of testcases) {
-            const result = englishStringifyList(data);
-            expect(result).toBe(expected);
         }
     });
 });

--- a/src/views/components/calendar/utils.ts
+++ b/src/views/components/calendar/utils.ts
@@ -32,7 +32,7 @@ export const CAL_MAP = {
     Saturday: 'SA',
 } as const satisfies Record<string, string>;
 
-export const DAY_NAME_TO_NUMBER = {
+const DAY_NAME_TO_NUMBER = {
     Sunday: 0,
     Monday: 1,
     Tuesday: 2,
@@ -66,9 +66,28 @@ export const formatToHHMMSS = (minutes: number) => {
     return `${hours}${mins}00`;
 };
 
+/**
+ * Formats a date in the format YYYYMMDD'T'HHmmss.
+ *
+ * @param date - The date to format.
+ * @returns
+ */
 const iCalDateFormat = <DateType extends Date>(date: DateArg<DateType>) =>
     formatDate(date, "yyyyMMdd'T'HHmmss", { in: TZ });
 
+const ISO_DATE_FORMAT = 'yyyy-MM-dd';
+
+/**
+ * Returns the next day of the given date, inclusive of the given day.
+ *
+ * If the given date is the given day, the same date is returned.
+ *
+ * For example, a Monday targeting a Wednesday will return the next Wednesday, but if it was targeting a Monday it would return the same date.
+ *
+ * @param date - The date to increment.
+ * @param day - The day to increment to. (0 = Sunday, 1 = Monday, etc.)
+ * @returns The next day of the given date, inclusive of the given day.
+ */
 const nextDayInclusive = <DateType extends Date, ResultDate extends Date = DateType>(
     date: DateArg<DateType>,
     day: Day
@@ -117,7 +136,7 @@ export const saveAsCal = async () => {
             }
 
             const startDate = nextDayInclusive(
-                parse(academicCalendar.firstClassDate, 'yyyy-MM-dd', new Date()),
+                parse(academicCalendar.firstClassDate, ISO_DATE_FORMAT, new Date()),
                 DAY_NAME_TO_NUMBER[days[0]!]
             );
 
@@ -136,18 +155,18 @@ export const saveAsCal = async () => {
                 { in: TZ }
             );
 
-            const untilDate = addDays(parse(academicCalendar.lastClassDate, 'yyyy-MM-dd', new Date()), 1);
+            const untilDate = addDays(parse(academicCalendar.lastClassDate, ISO_DATE_FORMAT, new Date()), 1);
 
             const excludedDates = academicCalendar.breakDates
                 .flatMap(breakDate => {
                     if (Array.isArray(breakDate)) {
                         return eachDayOfInterval({
-                            start: parse(breakDate[0], 'yyyy-MM-dd', new Date()),
-                            end: parse(breakDate[1], 'yyyy-MM-dd', new Date()),
+                            start: parse(breakDate[0], ISO_DATE_FORMAT, new Date()),
+                            end: parse(breakDate[1], ISO_DATE_FORMAT, new Date()),
                         });
                     }
 
-                    return parse(breakDate, 'yyyy-MM-dd', new Date());
+                    return parse(breakDate, ISO_DATE_FORMAT, new Date());
                 })
                 .map(date =>
                     setMultiple(

--- a/src/views/components/calendar/utils.ts
+++ b/src/views/components/calendar/utils.ts
@@ -277,7 +277,7 @@ export const saveAsCal = async () => {
         throw new Error('No schedule found');
     }
 
-    let icsString = 'BEGIN:VCALENDAR\nVERSION:2.0\nCALSCALE:GREGORIAN\nX-WR-CALNAME:My Schedule\n';
+    const icsString = scheduleToIcsString(schedule);
 
     downloadBlob(icsString, 'CALENDAR', 'schedule.ics');
 };

--- a/src/views/components/calendar/utils.ts
+++ b/src/views/components/calendar/utils.ts
@@ -202,7 +202,7 @@ export const meetingToIcsString = (course: Serialized<Course>, meeting: Serializ
     icsString += `DTEND;TZID=${TIMEZONE_ID}:${endDateFormatted}\n`;
     icsString += `RRULE:FREQ=WEEKLY;BYDAY=${icsDays};UNTIL=${untilDateFormatted}\n`;
     icsString += `EXDATE;TZID=${TIMEZONE_ID}:${excludedDatesFormatted.join(',')}\n`;
-    icsString += `SUMMARY:${course.department} ${course.number} — ${course.courseName}\n`;
+    icsString += `SUMMARY:${course.department} ${course.number} \u2013 ${course.courseName}\n`;
 
     if (location?.building || location?.building) {
         const locationFormatted = `${location?.building ?? ''} ${location?.room ?? ''}`.trim();

--- a/src/views/components/calendar/utils.ts
+++ b/src/views/components/calendar/utils.ts
@@ -1,4 +1,4 @@
-import { tz } from '@date-fns/tz';
+import { tz, TZDate } from '@date-fns/tz';
 import { UserScheduleStore } from '@shared/storage/UserScheduleStore';
 import type { Course } from '@shared/types/Course';
 import type { CourseMeeting } from '@shared/types/CourseMeeting';
@@ -16,7 +16,6 @@ import {
     nextDay,
     parseISO,
     set as setMultiple,
-    toDate,
 } from 'date-fns';
 import { toBlob } from 'html-to-image';
 
@@ -97,15 +96,12 @@ const iCalDateFormat = <DateType extends Date>(date: DateArg<DateType>) =>
  * @param day - The day to increment to. (0 = Sunday, 1 = Monday, etc.)
  * @returns The next day of the given date, inclusive of the given day.
  */
-export const nextDayInclusive = <DateType extends Date, ResultDate extends Date = DateType>(
-    date: DateArg<DateType>,
-    day: Day
-): ResultDate => {
-    if (getDay(date) === day) {
-        return toDate(date);
+export const nextDayInclusive = (date: Date, day: Day): TZDate => {
+    if (getDay(date, { in: TZ }) === day) {
+        return new TZDate(date, TIMEZONE_ID);
     }
 
-    return nextDay(date, day);
+    return nextDay(date, day, { in: TZ });
 };
 
 /**

--- a/src/views/components/calendar/utils.ts
+++ b/src/views/components/calendar/utils.ts
@@ -202,7 +202,7 @@ export const meetingToIcsString = (course: Serialized<Course>, meeting: Serializ
     icsString += `DTEND;TZID=${TIMEZONE_ID}:${endDateFormatted}\n`;
     icsString += `RRULE:FREQ=WEEKLY;BYDAY=${icsDays};UNTIL=${untilDateFormatted}\n`;
     icsString += `EXDATE;TZID=${TIMEZONE_ID}:${excludedDatesFormatted.join(',')}\n`;
-    icsString += `SUMMARY:${course.fullName}\n`;
+    icsString += `SUMMARY:${course.department} ${course.number} — ${course.courseName}\n`;
 
     if (location?.building || location?.building) {
         const locationFormatted = `${location?.building ?? ''} ${location?.room ?? ''}`.trim();

--- a/src/views/components/calendar/utils.ts
+++ b/src/views/components/calendar/utils.ts
@@ -1,5 +1,7 @@
 import { tz } from '@date-fns/tz';
 import { UserScheduleStore } from '@shared/storage/UserScheduleStore';
+import type { Course } from '@shared/types/Course';
+import type { CourseMeeting } from '@shared/types/CourseMeeting';
 import Instructor from '@shared/types/Instructor';
 import type { UserSchedule } from '@shared/types/UserSchedule';
 import { downloadBlob } from '@shared/util/downloadBlob';
@@ -19,8 +21,6 @@ import {
 import { toBlob } from 'html-to-image';
 
 import { academicCalendars } from './academic-calendars';
-import type { CourseMeeting } from '@shared/types/CourseMeeting';
-import type { Course } from '@shared/types/Course';
 
 // Do all timezone calculations relative to UT's timezone
 const TIMEZONE_ID = 'America/Chicago';

--- a/src/views/components/calendar/utils.ts
+++ b/src/views/components/calendar/utils.ts
@@ -5,6 +5,7 @@ import type { CourseMeeting } from '@shared/types/CourseMeeting';
 import Instructor from '@shared/types/Instructor';
 import type { UserSchedule } from '@shared/types/UserSchedule';
 import { downloadBlob } from '@shared/util/downloadBlob';
+import { englishStringifyList } from '@shared/util/string';
 import type { Serialized } from 'chrome-extension-toolkit';
 import type { DateArg, Day } from 'date-fns';
 import {
@@ -102,25 +103,6 @@ export const nextDayInclusive = (date: Date, day: Day): TZDate => {
     }
 
     return nextDay(date, day, { in: TZ });
-};
-
-/**
- *  Stringifies a list of items in English format.
- *
- * @param items - The list of items to stringify.
- * @returns A string representation of the list in English format.
- * @example
- * englishStringifyList([]) // ''
- * englishStringifyList(['Alice']) // 'Alice'
- * englishStringifyList(['Alice', 'Bob']) // 'Alice and Bob'
- * englishStringifyList(['Alice', 'Bob', 'Charlie']) // 'Alice, Bob, and Charlie'
- */
-export const englishStringifyList = (items: readonly string[]): string => {
-    if (items.length === 0) return '';
-    if (items.length === 1) return items[0]!;
-    if (items.length === 2) return `${items[0]} and ${items[1]}`;
-
-    return `${items.slice(0, -1).join(', ')}, and ${items.at(-1)}`;
 };
 
 /**


### PR DESCRIPTION
Now will export classes based on the academic calendar. Allows for skipping holidays and multi-day breaks. Accounts for semesters by using the semester info on the course itself, so it's legal to have a schedule with multiple semesters (though, that should be prevented in general, but that will be a separate PR).

Resolves #451

Drawbacks: Doesn't support winter terms or any of the various summer terms, except it interprets all summer courses as full-term summer courses.

![image](https://github.com/user-attachments/assets/0f8779bc-a6cd-4882-b72f-aef7c46d8d6c)
![image](https://github.com/user-attachments/assets/6fab4b48-f44d-4648-b43c-057e9085929e)
![image](https://github.com/user-attachments/assets/a50c7c5c-cb11-4de2-8149-37697e11bbd7)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/535)
<!-- Reviewable:end -->
