### PR TITLE
chore: Change the highlight color on-hover over grade distribution bars to off-white/50 

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -140,7 +140,7 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
             tickWidth: 1,
             tickLength: 10,
             tickColor: '#9CADB7',
-            crosshair: { color: extendedColors.theme.offwhite },
+            crosshair: { color: `${extendedColors.theme.offwhite}80` },
             lineColor: '#9CADB7',
         },
         yAxis: {


### PR DESCRIPTION
Fixes #518 

**Before:**
![image](https://github.com/user-attachments/assets/67b921e3-0166-4def-92c0-f9e5887c5d6f)

**After:**
![image](https://github.com/user-attachments/assets/a17e6e7f-9d5a-41c1-9859-6c37c22f78ac)
