### PR TITLE
feat: ensure unique splash text on schedule change

### DIFF
--- a/src/views/components/PopupMain.tsx
+++ b/src/views/components/PopupMain.tsx
@@ -66,11 +66,19 @@ export default function PopupMain(): JSX.Element {
     };
 
     useEffect(() => {
-        const randomIndex = Math.floor(Math.random() * splashText.length);
-        setFunny(
-            splashText[randomIndex] ?? 'If you are seeing this, something has gone horribly wrong behind the scenes.'
-        );
-    }, []);
+        setFunny(prevFunny => {
+            // Ensure that the next splash text is not the same as the previous one
+            const splashTextWithoutCurrent = splashText.filter(text => text !== prevFunny);
+            const randomIndex = Math.floor(Math.random() * splashTextWithoutCurrent.length);
+
+            return (
+                splashTextWithoutCurrent[randomIndex] ??
+                'If you are seeing this, something has gone horribly wrong behind the scenes.'
+            );
+        });
+
+        // Generate a new splash text every time the active schedule changes
+    }, [activeSchedule.id]);
 
     const handleOpenOptions = async () => {
         const url = chrome.runtime.getURL('/options.html');


### PR DESCRIPTION
Before: swapping between multiple empty schedules shows the same splash text. It's jarring.

https://github.com/user-attachments/assets/659efd73-cb65-45b9-8d71-20bdfadebe91

After: swapping between multiple empty schedules show a new splash text every time. It's beautiful.

https://github.com/user-attachments/assets/16adf601-6c3a-45fc-99c0-a7625531036a

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/554)
<!-- Reviewable:end -->
