### PR TITLE
feat: Implements the Quick Add Feature

### DIFF
--- a/src/stories/components/QuickAddDropdown.stories.tsx
+++ b/src/stories/components/QuickAddDropdown.stories.tsx
@@ -1,0 +1,68 @@
+import { ImageSquare } from '@phosphor-icons/react';
+import type { Meta, StoryObj } from '@storybook/react';
+import Dropdown from '@views/components/common/Dropdown';
+
+const meta = {
+    title: 'Components/Common/QuickAddDropdown',
+    component: Dropdown,
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+} satisfies Meta<typeof Dropdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+    args: {
+        placeholderText: 'Select an option...',
+        options: Array(30)
+            .fill(null)
+            .map((_, i) => ({ id: `${i + 1}`, label: `Option ${i + 1}` })),
+        // { id: '1', label: 'Option 1' },
+        // { id: '2', label: 'Option 2' },
+        // { id: '3', label: 'Option 3' },
+        // ,
+        selectedOption: undefined,
+        icon: ImageSquare,
+        disabled: false,
+        className: '',
+        onOptionChange: newOption => console.log(newOption),
+        iconProps: {},
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        placeholderText: 'Select an option...',
+        options: [
+            { id: '1', label: 'Option 1' },
+            { id: '2', label: 'Option 2' },
+            { id: '3', label: 'Option 3' },
+        ],
+        selectedOption: undefined,
+        icon: ImageSquare,
+        disabled: true,
+        className: '',
+        onOptionChange: newOption => console.log(newOption),
+        iconProps: {},
+    },
+};
+
+export const NoIcon: Story = {
+    args: {
+        placeholderText: 'Select an option...',
+        options: [
+            { id: '1', label: 'Option 1' },
+            { id: '2', label: 'Option 2' },
+            { id: '3', label: 'Option 3' },
+        ],
+        selectedOption: undefined,
+        icon: undefined,
+        disabled: false,
+        className: '',
+        onOptionChange: newOption => console.log(newOption),
+        iconProps: {},
+    },
+};

--- a/src/stories/components/QuickAddModal.stories.tsx
+++ b/src/stories/components/QuickAddModal.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import QuickAddModal from '@views/components/common/QuickAddModal';
+import React from 'react';
+
+const meta = {
+    title: 'Components/Common/QuickAddModal',
+    component: QuickAddModal,
+    parameters: {
+        // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+        layout: 'centered',
+    },
+    // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+    tags: ['autodocs'],
+} satisfies Meta<typeof QuickAddModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+    render: () => <InnerComponent />,
+};
+
+const InnerComponent = () => <QuickAddModal />;

--- a/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
+++ b/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
@@ -5,6 +5,7 @@ import { Button } from '@views/components/common/Button';
 import DialogProvider from '@views/components/common/DialogProvider/DialogProvider';
 import Divider from '@views/components/common/Divider';
 import { ExtensionRootWrapper, styleResetClass } from '@views/components/common/ExtensionRoot/ExtensionRoot';
+import QuickAddModal from '@views/components/common/QuickAddModal';
 import ScheduleTotalHoursAndCourses from '@views/components/common/ScheduleTotalHoursAndCourses';
 import useSchedules from '@views/hooks/useSchedules';
 import clsx from 'clsx';
@@ -50,6 +51,7 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
             {/* min-w-[310px] is the value with all the buttons */}
             <div className={clsx(styles.cqInline, 'flex flex-1 gap-5 min-w-[45x] screenshot:hidden')}>
                 <div className={clsx(styles.primaryActions, 'min-w-fit flex gap-5')}>
+                    <QuickAddModal />
                     <DialogProvider>
                         <Menu>
                             <MenuButton className='bg-transparent'>
@@ -102,10 +104,7 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
                             </MenuItems>
                         </Menu>
                     </DialogProvider>
-                    {/* <Button className='invisible' color='ut-black' size='small' variant='minimal' icon={PlusCircle}>
-                        Quick Add
-                    </Button>
-                    <Button className='invisible' color='ut-black' size='small' variant='minimal' icon={SelectionPlus}>
+                    {/* <Button className='invisible' color='ut-black' size='small' variant='minimal' icon={SelectionPlus}>
                         Block
                     </Button> */}
                 </div>

--- a/src/views/components/common/Dropdown.tsx
+++ b/src/views/components/common/Dropdown.tsx
@@ -1,0 +1,100 @@
+import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react';
+import type { Icon, IconProps } from '@phosphor-icons/react';
+import { CaretDown } from '@phosphor-icons/react';
+import Text from '@views/components/common/Text/Text';
+import clsx from 'clsx';
+import React from 'react';
+
+import { ExtensionRootWrapper, styleResetClass } from './ExtensionRoot/ExtensionRoot';
+
+/**
+ * Type for the dropdown option.
+ */
+export type DropdownOption = {
+    id: string;
+    label: string;
+};
+
+interface Props {
+    className?: string;
+    placeholderText?: string;
+    options?: DropdownOption[];
+    selectedOption: DropdownOption | undefined;
+    onOptionChange?: (newOption: DropdownOption) => void;
+    icon?: Icon;
+    iconProps?: IconProps;
+    disabled?: boolean;
+}
+
+/**
+ * A reusable dropdown component that follows the design system of the extension.
+ * @returns
+ */
+export default function Dropdown({
+    className,
+    placeholderText,
+    options,
+    selectedOption,
+    onOptionChange,
+    icon,
+    iconProps,
+    disabled,
+}: React.PropsWithChildren<Props>): JSX.Element {
+    const Icon = icon;
+    return (
+        <div className={clsx('h-9 w-[312px] flex flex-row items-center gap-spacing-5', className)}>
+            {Icon && <Icon {...iconProps} className={clsx('h-7 w-7', iconProps?.className)} />}
+            <Listbox value={selectedOption} onChange={onOptionChange}>
+                <ListboxButton
+                    className='h-full w-full flex flex-row items-center justify-between gap-spacing-3 border border-ut-offwhite/50 border-rounded bg-transparent px-spacing-4 disabled:bg-ut-offwhite/20'
+                    disabled={disabled}
+                >
+                    {selectedOption ? (
+                        <Text className='truncate text-ut-black'>{selectedOption.label}</Text>
+                    ) : (
+                        placeholderText && <Text className='text-ut-black/50'>{placeholderText}</Text>
+                    )}
+                    <CaretDown className='h-5 w-5' />
+                </ListboxButton>
+                <ListboxOptions
+                    as={ExtensionRootWrapper}
+                    anchor='bottom start'
+                    className={clsx(
+                        styleResetClass,
+                        'mt-spacing-1',
+                        {
+                            'min-w-[272px]': icon !== undefined,
+                            'min-w-[312px]': icon === undefined,
+                        },
+                        'origin-top-right rounded bg-white text-black shadow-lg transition border border-ut-offwhite/50 focus:outline-none',
+                        'data-[closed]:(opacity-0 scale-95)',
+                        'data-[enter]:(ease-out-expo duration-150)',
+                        'data-[leave]:(ease-out duration-50)',
+                        {
+                            'h-fit': !options || options?.length < 5,
+                            'h-[200px] overflow-y-auto': options && options?.length >= 5,
+                        },
+                        'flex flex-col gap-spacing-3 px-spacing-4 py-spacing-3'
+                    )}
+                >
+                    {options?.map(option => (
+                        <ListboxOption
+                            key={option.id}
+                            value={option}
+                            className={clsx(
+                                'cursor-pointer select-none rounded data-[focus]:bg-ut-offwhite/20 data-[disabled]:text-ut-black/50 data-[disabled]:cursor-not-allowed',
+                                {
+                                    'text-ut-black': selectedOption?.id === option.id,
+                                    'text-ut-black/50': selectedOption?.id !== option.id,
+                                },
+                                'px-spacing-3 py-spacing-2'
+                            )}
+                        >
+                            <Text variant='small'>{option.label}</Text>
+                        </ListboxOption>
+                    ))}
+                </ListboxOptions>
+            </Listbox>
+        </div>
+    );
+}

--- a/src/views/components/common/QuickAddModal.tsx
+++ b/src/views/components/common/QuickAddModal.tsx
@@ -1,13 +1,249 @@
-import { Listbox, ListboxButton, Menu, MenuButton, MenuItems } from '@headlessui/react';
-import { CaretDown, GraduationCap, Plus, PlusCircle } from '@phosphor-icons/react';
+import { Input, Menu, MenuButton, MenuItems } from '@headlessui/react';
+import { ChalkboardTeacher, GraduationCap, HashStraight, ListNumbers, Plus, PlusCircle } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React from 'react';
 
 import { Button } from './Button';
 import DialogProvider from './DialogProvider/DialogProvider';
 import Divider from './Divider';
+import type { DropdownOption } from './Dropdown';
+import Dropdown from './Dropdown';
 import { ExtensionRootWrapper, styleResetClass } from './ExtensionRoot/ExtensionRoot';
 import Text from './Text/Text';
+
+const FIELDS_OF_STUDY = [
+    { id: 'A I', label: 'A I - Artificial Intelligence' },
+    { id: 'AAS', label: 'AAS - Asian American Studies' },
+    { id: 'ACC', label: 'ACC - Accounting' },
+    { id: 'ADV', label: 'ADV - Advertising' },
+    { id: 'AED', label: 'AED - Art Education' },
+    { id: 'AET', label: 'AET - Arts/Entertainment Technology' },
+    { id: 'AFR', label: 'AFR - African/African Diaspora Studies' },
+    { id: 'AFS', label: 'AFS - Air Force Science' },
+    { id: 'AHC', label: 'AHC - Ancient History/Classical Civ' },
+    { id: 'AMS', label: 'AMS - American Studies' },
+    { id: 'ANS', label: 'ANS - Asian Studies' },
+    { id: 'ANT', label: 'ANT - Anthropology' },
+    { id: 'ARA', label: 'ARA - Arabic' },
+    { id: 'ARC', label: 'ARC - Architecture' },
+    { id: 'ARE', label: 'ARE - Architectural Engineering' },
+    { id: 'ARH', label: 'ARH - Art History' },
+    { id: 'ARI', label: 'ARI - Architectural Interior Design' },
+    { id: 'ART', label: 'ART - Art, Studio' },
+    { id: 'ASE', label: 'ASE - Aerospace Engineering' },
+    { id: 'ASL', label: 'ASL - American Sign Language' },
+    { id: 'AST', label: 'AST - Astronomy' },
+    { id: 'B A', label: 'B A - Business Administration' },
+    { id: 'BAX', label: 'BAX - Business Analytics' },
+    { id: 'BCH', label: 'BCH - Biochemistry' },
+    { id: 'BDP', label: 'BDP - Bridging Disciplines' },
+    { id: 'BGS', label: 'BGS - Business/Government/Society' },
+    { id: 'BIO', label: 'BIO - Biology' },
+    { id: 'BME', label: 'BME - Biomedical Engineering' },
+    { id: 'BSN', label: 'BSN - Bassoon' },
+    { id: 'C C', label: 'C C - Classical Civilization' },
+    { id: 'C E', label: 'C E - Civil Engineering' },
+    { id: 'C L', label: 'C L - Comparative Literature' },
+    { id: 'C S', label: 'C S - Computer Science' },
+    { id: 'CDI', label: 'CDI - Critical Disability Studies' },
+    { id: 'CGS', label: 'CGS - Cognitive Science' },
+    { id: 'CH', label: 'CH - Chemistry' },
+    { id: 'CHE', label: 'CHE - Chemical Engineering' },
+    { id: 'CHI', label: 'CHI - Chinese' },
+    { id: 'CIV', label: 'CIV - Civics' },
+    { id: 'CLA', label: 'CLA - Clarinet' },
+    { id: 'CLD', label: 'CLD - Communication and Leadership' },
+    { id: 'CMS', label: 'CMS - Communication Studies' },
+    { id: 'COE', label: 'COE - Computational Engineering' },
+    { id: 'COM', label: 'COM - Communication' },
+    { id: 'CON', label: 'CON - Conducting' },
+    { id: 'CRP', label: 'CRP - Community/Regional Planning' },
+    { id: 'CRW', label: 'CRW - Creative Writing' },
+    { id: 'CSE', label: 'CSE - Computational Science/Engineering' },
+    { id: 'CTI', label: 'CTI - Core Texts and Ideas' },
+    { id: 'CZ', label: 'CZ - Czech' },
+    { id: 'D B', label: 'D B - Double Bass' },
+    { id: 'D S', label: 'D S - Decision Science' },
+    { id: 'DAN', label: 'DAN - Danish' },
+    { id: 'DCH', label: 'DCH - Dutch' },
+    { id: 'DES', label: 'DES - Design' },
+    { id: 'DEV', label: 'DEV - Developmental Studies' },
+    { id: 'DRS', label: 'DRS - Drum Set' },
+    { id: 'DSC', label: 'DSC - Data Science' },
+    { id: 'E', label: 'E - English' },
+    { id: 'E M', label: 'E M - Engineering Mechanics' },
+    { id: 'E S', label: 'E S - Engineering Studies' },
+    { id: 'ECE', label: 'ECE - Electrical/Computer Engineering' },
+    { id: 'ECO', label: 'ECO - Economics' },
+    { id: 'EDC', label: 'EDC - Curriculum and Instruction' },
+    { id: 'EDP', label: 'EDP - Educational Psychology' },
+    { id: 'EDU', label: 'EDU - Education' },
+    { id: 'EER', label: 'EER - Energy and Earth Resources' },
+    { id: 'ELP', label: 'ELP - Educational Leadership/Policy' },
+    { id: 'ENM', label: 'ENM - Engineering Management' },
+    { id: 'ENS', label: 'ENS - Ensemble' },
+    { id: 'ESL', label: 'ESL - English as a Second Language' },
+    { id: 'EUP', label: 'EUP - Euphonium' },
+    { id: 'EUS', label: 'EUS - European Studies' },
+    { id: 'EVE', label: 'EVE - Environmental Engineering' },
+    { id: 'EVS', label: 'EVS - Environmental Science' },
+    { id: 'F A', label: 'F A - Fine Arts' },
+    { id: 'F C', label: 'F C - French Civilization' },
+    { id: 'F H', label: 'F H - French Horn' },
+    { id: 'FIN', label: 'FIN - Finance' },
+    { id: 'FLU', label: 'FLU - Flute' },
+    { id: 'FR', label: 'FR - French' },
+    { id: 'G E', label: 'G E - General Engineering' },
+    { id: 'GEO', label: 'GEO - Geological Sciences' },
+    { id: 'GER', label: 'GER - German' },
+    { id: 'GK', label: 'GK - Greek' },
+    { id: 'GOV', label: 'GOV - Government' },
+    { id: 'GRG', label: 'GRG - Geography' },
+    { id: 'GRS', label: 'GRS - Graduate School' },
+    { id: 'GSD', label: 'GSD - German/Scandinavian/Dutch' },
+    { id: 'GUI', label: 'GUI - Guitar' },
+    { id: 'H E', label: 'H E - Human Ecology' },
+    { id: 'H S', label: 'H S - Health and Society' },
+    { id: 'HAR', label: 'HAR - Harp' },
+    { id: 'HDF', label: 'HDF - Human Development/Family Sciences' },
+    { id: 'HDO', label: 'HDO - Human Dimensions of Orgs' },
+    { id: 'HEB', label: 'HEB - Hebrew' },
+    { id: 'HED', label: 'HED - Health Education' },
+    { id: 'HHM', label: 'HHM - Humanities, Health, and Medici' },
+    { id: 'HIN', label: 'HIN - Hindi' },
+    { id: 'HIS', label: 'HIS - History' },
+    { id: 'HMN', label: 'HMN - Humanities' },
+    { id: 'I', label: 'I - Informatics' },
+    { id: 'I B', label: 'I B - International Business' },
+    { id: 'ILA', label: 'ILA - Iberian/Latin American Langs' },
+    { id: 'INB', label: 'INB - Integrative Biology' },
+    { id: 'INF', label: 'INF - Information Studies' },
+    { id: 'IRG', label: 'IRG - Intl Relations/Global Studies' },
+    { id: 'ISP', label: 'ISP - Information Security &amp; Privacy' },
+    { id: 'ITC', label: 'ITC - Italian Civilization' },
+    { id: 'ITD', label: 'ITD - Integrated Design' },
+    { id: 'ITL', label: 'ITL - Italian' },
+    { id: 'J', label: 'J - Journalism' },
+    { id: 'J S', label: 'J S - Jewish Studies' },
+    { id: 'JPN', label: 'JPN - Japanese' },
+    { id: 'KIN', label: 'KIN - Kinesiology' },
+    { id: 'KOR', label: 'KOR - Korean' },
+    { id: 'L A', label: 'L A - Liberal Arts' },
+    { id: 'LAH', label: 'LAH - Liberal Arts Honors' },
+    { id: 'LAL', label: 'LAL - Indigenous Languages of Latin America' },
+    { id: 'LAR', label: 'LAR - Landscape Architecture' },
+    { id: 'LAS', label: 'LAS - Latin American Studies' },
+    { id: 'LAT', label: 'LAT - Latin' },
+    { id: 'LAW', label: 'LAW - Law' },
+    { id: 'LEB', label: 'LEB - Legal Environment of Business' },
+    { id: 'LIN', label: 'LIN - Linguistics' },
+    { id: 'LTC', label: 'LTC - Language Teaching/Coordination' },
+    { id: 'M', label: 'M - Mathematics' },
+    { id: 'M E', label: 'M E - Mechanical Engineering' },
+    { id: 'M S', label: 'M S - Military Science' },
+    { id: 'MAL', label: 'MAL - Malayalam' },
+    { id: 'MAN', label: 'MAN - Management' },
+    { id: 'MAS', label: 'MAS - Mexican American Studies' },
+    { id: 'MBS', label: 'MBS - Molecular Biosciences' },
+    { id: 'MEL', label: 'MEL - Middle Eastern Langs/Cultures' },
+    { id: 'MES', label: 'MES - Middle Eastern Studies' },
+    { id: 'MFG', label: 'MFG - Manufacturing Systems Eng' },
+    { id: 'MIS', label: 'MIS - Management Information Systems' },
+    { id: 'MKT', label: 'MKT - Marketing' },
+    { id: 'MLS', label: 'MLS - Medical Laboratory Science' },
+    { id: 'MNS', label: 'MNS - Marine Science' },
+    { id: 'MOL', label: 'MOL - Molecular Biology' },
+    { id: 'MSE', label: 'MSE - Materials Science/Engineer' },
+    { id: 'MUS', label: 'MUS - Music' },
+    { id: 'N', label: 'N - Nursing' },
+    { id: 'N S', label: 'N S - Naval Science' },
+    { id: 'NEU', label: 'NEU - Neuroscience' },
+    { id: 'NOR', label: 'NOR - Norwegian' },
+    { id: 'NSC', label: 'NSC - Natural Sciences' },
+    { id: 'NTR', label: 'NTR - Nutrition' },
+    { id: 'O M', label: 'O M - Operations Management' },
+    { id: 'OBO', label: 'OBO - Oboe' },
+    { id: 'OPR', label: 'OPR - Opera' },
+    { id: 'ORG', label: 'ORG - Organ' },
+    { id: 'ORI', label: 'ORI - Operations Rsrch/Industrial Engr' },
+    { id: 'P A', label: 'P A - Public Affairs' },
+    { id: 'P L', label: 'P L - Public Leadership' },
+    { id: 'P R', label: 'P R - Public Relations' },
+    { id: 'P S', label: 'P S - Physical Science' },
+    { id: 'PBH', label: 'PBH - Public Health' },
+    { id: 'PED', label: 'PED - Physical Education' },
+    { id: 'PER', label: 'PER - Percussion' },
+    { id: 'PGE', label: 'PGE - Petroleum and Geosystems Engineering' },
+    { id: 'PGS', label: 'PGS - Pharmacy Graduate Studies' },
+    { id: 'PHL', label: 'PHL - Philosophy' },
+    { id: 'PHM', label: 'PHM - Pharmacy PharmD' },
+    { id: 'PHY', label: 'PHY - Physics' },
+    { id: 'PIA', label: 'PIA - Piano' },
+    { id: 'POL', label: 'POL - Polish' },
+    { id: 'POR', label: 'POR - Portuguese' },
+    { id: 'PPE', label: 'PPE - Philosophy, Politics, and Econ' },
+    { id: 'PRC', label: 'PRC - Portuguese Civilization' },
+    { id: 'PRS', label: 'PRS - Persian' },
+    { id: 'PSY', label: 'PSY - Psychology' },
+    { id: 'R E', label: 'R E - Real Estate' },
+    { id: 'R M', label: 'R M - Risk Management' },
+    { id: 'R S', label: 'R S - Religious Studies' },
+    { id: 'RBT', label: 'RBT - Robotics' },
+    { id: 'REE', label: 'REE - Russian/East European/Eurasian' },
+    { id: 'RHE', label: 'RHE - Rhetoric and Writing' },
+    { id: 'RIM', label: 'RIM - Race/Indigeneity/Migration' },
+    { id: 'RTF', label: 'RTF - Radio-Television-Film' },
+    { id: 'RUS', label: 'RUS - Russian' },
+    { id: 'S C', label: 'S C - Serbian/Croatian' },
+    { id: 'S S', label: 'S S - Social Science' },
+    { id: 'S W', label: 'S W - Social Work' },
+    { id: 'SAN', label: 'SAN - Sanskrit' },
+    { id: 'SAX', label: 'SAX - Saxophone' },
+    { id: 'SDS', label: 'SDS - Statistics and Data Sciences' },
+    { id: 'SED', label: 'SED - Special Education' },
+    { id: 'SLH', label: 'SLH - Speech/Language/Hearing Sciences' },
+    { id: 'SOC', label: 'SOC - Sociology' },
+    { id: 'SPC', label: 'SPC - Spanish Civilization' },
+    { id: 'SPN', label: 'SPN - Spanish' },
+    { id: 'STA', label: 'STA - Statistics' },
+    { id: 'STC', label: 'STC - Science/Technology Commerce' },
+    { id: 'STM', label: 'STM - Sci/Tech/Engr/Math Studies' },
+    { id: 'SUS', label: 'SUS - Sustainability Studies' },
+    { id: 'SWE', label: 'SWE - Swedish' },
+    { id: 'T C', label: 'T C - Tutorial Course' },
+    { id: 'T D', label: 'T D - Theatre and Dance' },
+    { id: 'TAM', label: 'TAM - Tamil' },
+    { id: 'TBA', label: 'TBA - Tuba' },
+    { id: 'TRO', label: 'TRO - Trombone' },
+    { id: 'TRU', label: 'TRU - Trumpet' },
+    { id: 'TUR', label: 'TUR - Turkish' },
+    { id: 'TXA', label: 'TXA - Textiles and Apparel' },
+    { id: 'U D', label: 'U D - Urban Design' },
+    { id: 'UGS', label: 'UGS - Undergraduate Studies' },
+    { id: 'UKR', label: 'UKR - Ukrainian' },
+    { id: 'URB', label: 'URB - Urban Studies' },
+    { id: 'URD', label: 'URD - Urdu' },
+    { id: 'UTL', label: 'UTL - UTeach-Liberal Arts' },
+    { id: 'UTS', label: 'UTS - UTeach-Natural Sciences' },
+    { id: 'V C', label: 'V C - Violoncello' },
+    { id: 'VIA', label: 'VIA - Viola' },
+    { id: 'VIO', label: 'VIO - Violin' },
+    { id: 'VOI', label: 'VOI - Voice' },
+    { id: 'WGS', label: "WGS - Women's and Gender Studies" },
+    { id: 'WRT', label: 'WRT - Writing' },
+    { id: 'YID', label: 'YID - Yiddish' },
+    { id: 'YOR', label: 'YOR - Yoruba' },
+] as const satisfies DropdownOption[];
+
+const COURSE_NUMBERS = [
+    { id: '1', label: 'CS101' },
+    { id: '2', label: 'MATH202' },
+] as const satisfies DropdownOption[];
+
+const SECTIONS = [
+    { id: '1', label: 'Section A' },
+    { id: '2', label: 'Section B' },
+] as const satisfies DropdownOption[];
 
 /**
  * QuickAddModal component
@@ -15,6 +251,11 @@ import Text from './Text/Text';
  * This component renders a button with a PlusCircle icon and the label "Quick Add".
  */
 export default function QuickAddModal(): JSX.Element {
+    const [field, setField] = React.useState<DropdownOption | undefined>(undefined);
+    const [courseNumber, setCourseNumber] = React.useState<DropdownOption | undefined>(undefined);
+    const [section, setSection] = React.useState<DropdownOption | undefined>(undefined);
+    const [unique, setUnique] = React.useState<string>('');
+
     return (
         <DialogProvider>
             <Menu>
@@ -39,18 +280,39 @@ export default function QuickAddModal(): JSX.Element {
                 >
                     <div className='flex flex-col gap-spacing-6'>
                         <div className='flex flex-col gap-spacing-5'>
-                            <div className='h-[35px] w-full flex flex-row gap-spacing-5'>
-                                <GraduationCap size='28' className='self-center' />
-                                <Listbox>
-                                    <ListboxButton className='h-full w-full flex flex-row items-center justify-between border border-rounded bg-ut-offwhite/25 px-spacing-4'>
-                                        <Text className='text-ut-black/50'>Select Field of Study...</Text>
-                                        <CaretDown size='20' className='self-center text-ut-black' />
-                                    </ListboxButton>
-                                </Listbox>
-                            </div>
-                            <Text>Select Field of Study</Text>
-                            <Text>Course Number</Text>
-                            <Text>Select Section</Text>
+                            <Dropdown
+                                className='w-full'
+                                placeholderText='Select Field of Study...'
+                                options={FIELDS_OF_STUDY}
+                                selectedOption={field}
+                                onOptionChange={f => {
+                                    setField(f === field ? undefined : f);
+                                    setCourseNumber(undefined);
+                                    setSection(undefined);
+                                }}
+                                icon={GraduationCap}
+                            />
+                            <Dropdown
+                                className='w-full'
+                                placeholderText='Select Course Number...'
+                                options={COURSE_NUMBERS}
+                                selectedOption={courseNumber}
+                                onOptionChange={c => {
+                                    setCourseNumber(c === courseNumber ? undefined : c);
+                                    setSection(undefined);
+                                }}
+                                icon={ListNumbers}
+                                disabled={!field}
+                            />
+                            <Dropdown
+                                className='w-full'
+                                placeholderText='Select Section...'
+                                options={SECTIONS}
+                                selectedOption={section}
+                                onOptionChange={s => setSection(s === section ? undefined : s)}
+                                icon={ChalkboardTeacher}
+                                disabled={!courseNumber}
+                            />
                         </div>
                         <div className='w-full flex flex-row items-center justify-center gap-spacing-4'>
                             <Divider orientation='horizontal' size='100%' />
@@ -59,8 +321,19 @@ export default function QuickAddModal(): JSX.Element {
                             </Text>
                             <Divider orientation='horizontal' size='100%' />
                         </div>
-                        <div>
-                            <Text>Unique ID</Text>
+                        <div className='h-9 w-full flex flex-row items-center justify-start gap-spacing-5'>
+                            <HashStraight className='h-7 w-7' />
+                            <Input
+                                value={unique}
+                                onChange={e => {
+                                    if (e.target.value === '' || /^\d+$/.test(e.target.value)) {
+                                        setUnique(e.target.value);
+                                    }
+                                }}
+                                maxLength={5}
+                                placeholder='Enter Unique Number...'
+                                className='h-full w-full border border-ut-offwhite/50 border-rounded px-spacing-4 py-spacing-1 focus:border-ut-black/50 disabled:bg-ut-offwhite/20 focus:outline-none focus:ring-0'
+                            />
                         </div>
                     </div>
                     <div className='w-full flex flex-row justify-end gap-spacing-5'>

--- a/src/views/components/common/QuickAddModal.tsx
+++ b/src/views/components/common/QuickAddModal.tsx
@@ -1,0 +1,17 @@
+import { PlusCircle } from '@phosphor-icons/react';
+import React from 'react';
+
+import { Button } from './Button';
+
+/**
+ * QuickAddModal component
+ *
+ * This component renders a button with a PlusCircle icon and the label "Quick Add".
+ */
+export default function QuickAddModal(): JSX.Element {
+    return (
+        <Button color='ut-black' size='small' variant='minimal' icon={PlusCircle}>
+            Quick Add
+        </Button>
+    );
+}

--- a/src/views/components/common/QuickAddModal.tsx
+++ b/src/views/components/common/QuickAddModal.tsx
@@ -1,7 +1,13 @@
-import { PlusCircle } from '@phosphor-icons/react';
+import { Listbox, ListboxButton, Menu, MenuButton, MenuItems } from '@headlessui/react';
+import { CaretDown, GraduationCap, Plus, PlusCircle } from '@phosphor-icons/react';
+import clsx from 'clsx';
 import React from 'react';
 
 import { Button } from './Button';
+import DialogProvider from './DialogProvider/DialogProvider';
+import Divider from './Divider';
+import { ExtensionRootWrapper, styleResetClass } from './ExtensionRoot/ExtensionRoot';
+import Text from './Text/Text';
 
 /**
  * QuickAddModal component
@@ -10,8 +16,63 @@ import { Button } from './Button';
  */
 export default function QuickAddModal(): JSX.Element {
     return (
-        <Button color='ut-black' size='small' variant='minimal' icon={PlusCircle}>
-            Quick Add
-        </Button>
+        <DialogProvider>
+            <Menu>
+                <MenuButton className='bg-transparent'>
+                    <Button color='ut-black' size='small' variant='minimal' icon={PlusCircle}>
+                        Quick Add
+                    </Button>
+                </MenuButton>
+                <MenuItems
+                    as={ExtensionRootWrapper}
+                    className={clsx([
+                        styleResetClass,
+                        'mt-spacing-3',
+                        'min-w-max origin-top-right rounded bg-white text-black shadow-lg transition border border-ut-offwhite/50 focus:outline-none',
+                        'data-[closed]:(opacity-0 scale-95)',
+                        'data-[enter]:(ease-out-expo duration-150)',
+                        'data-[leave]:(ease-out duration-50)',
+                        'flex flex-col gap-spacing-7 px-spacing-7 py-spacing-6 w-[400px]',
+                    ])}
+                    transition
+                    anchor='bottom start'
+                >
+                    <div className='flex flex-col gap-spacing-6'>
+                        <div className='flex flex-col gap-spacing-5'>
+                            <div className='h-[35px] w-full flex flex-row gap-spacing-5'>
+                                <GraduationCap size='28' className='self-center' />
+                                <Listbox>
+                                    <ListboxButton className='h-full w-full flex flex-row items-center justify-between border border-rounded bg-ut-offwhite/25 px-spacing-4'>
+                                        <Text className='text-ut-black/50'>Select Field of Study...</Text>
+                                        <CaretDown size='20' className='self-center text-ut-black' />
+                                    </ListboxButton>
+                                </Listbox>
+                            </div>
+                            <Text>Select Field of Study</Text>
+                            <Text>Course Number</Text>
+                            <Text>Select Section</Text>
+                        </div>
+                        <div className='w-full flex flex-row items-center justify-center gap-spacing-4'>
+                            <Divider orientation='horizontal' size='100%' />
+                            <Text className='w-fit text-nowrap uppercase' variant='small'>
+                                OR ADD BY UNIQUE NUMBER
+                            </Text>
+                            <Divider orientation='horizontal' size='100%' />
+                        </div>
+                        <div>
+                            <Text>Unique ID</Text>
+                        </div>
+                    </div>
+                    <div className='w-full flex flex-row justify-end gap-spacing-5'>
+                        <Button color='ut-black' size='regular' variant='minimal'>
+                            Cancel
+                        </Button>
+                        <Button color='ut-green' size='regular' variant='filled' icon={Plus}>
+                            Add Course
+                        </Button>
+                    </div>
+                </MenuItems>
+            </Menu>
+        </DialogProvider>
     );
 }

--- a/src/views/components/common/QuickAddModal.tsx
+++ b/src/views/components/common/QuickAddModal.tsx
@@ -1,4 +1,4 @@
-import { Input, Menu, MenuButton, MenuItems } from '@headlessui/react';
+import { Input, Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import { ChalkboardTeacher, GraduationCap, HashStraight, ListNumbers, Plus, PlusCircle } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React from 'react';
@@ -269,7 +269,7 @@ export default function QuickAddModal(): JSX.Element {
                     className={clsx([
                         styleResetClass,
                         'mt-spacing-3',
-                        'min-w-max origin-top-right rounded bg-white text-black shadow-lg transition border border-ut-offwhite/50 focus:outline-none',
+                        'min-w-max origin-top-left rounded bg-white text-black shadow-lg transition border border-ut-offwhite/50 focus:outline-none',
                         'data-[closed]:(opacity-0 scale-95)',
                         'data-[enter]:(ease-out-expo duration-150)',
                         'data-[leave]:(ease-out duration-50)',
@@ -337,10 +337,37 @@ export default function QuickAddModal(): JSX.Element {
                         </div>
                     </div>
                     <div className='w-full flex flex-row justify-end gap-spacing-5'>
-                        <Button color='ut-black' size='regular' variant='minimal'>
-                            Cancel
-                        </Button>
-                        <Button color='ut-green' size='regular' variant='filled' icon={Plus}>
+                        <MenuItem>
+                            {({ close }) => (
+                                <Button
+                                    color='ut-black'
+                                    size='regular'
+                                    variant='minimal'
+                                    onClick={() => {
+                                        setField(undefined);
+                                        setCourseNumber(undefined);
+                                        setSection(undefined);
+                                        setUnique('');
+                                        close();
+                                    }}
+                                >
+                                    Cancel
+                                </Button>
+                            )}
+                        </MenuItem>
+                        <Button
+                            color='ut-green'
+                            size='regular'
+                            variant='filled'
+                            icon={Plus}
+                            onClick={() => {
+                                setField(undefined);
+                                setCourseNumber(undefined);
+                                setSection(undefined);
+                                setUnique('');
+                            }}
+                            disabled={!section && unique.length !== 5}
+                        >
                             Add Course
                         </Button>
                     </div>


### PR DESCRIPTION
This PR closes #530.

> ### **Note (PR is WIP)** 
> PR is still in an early phase. The UI is the primary progress so far, and it still needs refactoring and review. I am still exploring the various approaches and how the features could be implemented. Feel free to also work on the issue, suggest changes, or even consider changing the features. 

## Implements the Quick Add Feature

The Quick Add feature is a button in the calendar toolbar that allows the user to quickly search for a course section or add a course with the unique ID instead of opening the course schedule site. The figma reference [here](https://www.figma.com/design/8tsCay2FRqctrdcZ3r9Ahw/UT-Registration-Plus-Design?node-id=7939-9641&m=dev).

### Screenshot

![image](https://github.com/user-attachments/assets/d59d23e5-cd0c-4cb8-9651-15c798dcaabf)

### Video

https://github.com/user-attachments/assets/58d10354-61c2-4343-ae7b-3d5bf66b5c19

### Implementation Notes

I believe the main challenge with this feature is how we can display accurate and updated course sections data with minimal processing and data fetches. There are 2 main approaches I can think of:
- Fully prefetch and preprocess the data once at build time (or even as a static file similar to grade distributions db), though this might cause issues if UT changed courses/sections later.
- Dynamically fetch the data as the user selects options, with some caching policy. This sounds nice, but it might be tricky because the fetch calls needs the user to be signed in to UT.

Looking at [UT Planner](https://utdirect.utexas.edu/apps/registrar/ut_planner/), finding the `Fields of study` and `course numbers` looks trivial, but finding all section numbers looks tricky and likely computationally expensive.

### TODO:

- [ ] Refactor: Move the `useState`s into a separate hook
- [ ] Fix: Make the options width grow dynamically instead of being hard coded
- [ ] Feat: Create a reusable component for the `Input` field
- [ ] Fix: fix why unique id input field displays different in storybook vs 
- [ ] Fix: Review and Improve on the UI/UX of the Dropdown menu
- [ ] Fix: Find a better place for the `FIELDS_OF_STUDY` array
- [ ] Feat: Create a service for fetching the courses
- [ ] Feat: handle course numbers with multiple topics (e.g. cs 378)
- [ ] Feat: Implement adding the course by Unique ID
- [ ] Feat: Make the `Add Course` actually add the course to the schedule