### PR TITLE
chore: Add a bigger "hitbox" to calendar sidebar buttons #519

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,5 +158,6 @@
     },
     "volta": {
         "node": "20.9.0"
-    }
+    },
+    "packageManager": "pnpm@10.6.4+sha512.da3d715bfd22a9a105e6e8088cfc7826699332ded60c423b14ec613a185f1602206702ff0fe4c438cb15c979081ce4cb02568e364b15174503a63c7a8e2a5f6c"
 }

--- a/src/views/components/calendar/Calendar.tsx
+++ b/src/views/components/calendar/Calendar.tsx
@@ -81,11 +81,12 @@ export default function Calendar(): JSX.Element {
                             <LargeLogo />
                             <Button
                                 variant='minimal'
+                                size='small'
                                 color='theme-black'
                                 onClick={() => {
                                     setShowSidebar(!showSidebar);
                                 }}
-                                className='h-fit screenshot:hidden !p-0'
+                                className='screenshot:hidden'
                                 icon={Sidebar}
                             />
                         </div>

--- a/src/views/components/calendar/CalendarFooter.tsx
+++ b/src/views/components/calendar/CalendarFooter.tsx
@@ -58,13 +58,7 @@ export default function CalendarFooter(): JSX.Element {
                 ))}
             </div>
             <div>
-                <Button
-                    className='h-fit w-fit !p-0'
-                    variant='minimal'
-                    icon={GearSix}
-                    color='ut-black'
-                    onClick={handleOpenOptions}
-                />
+                <Button variant='minimal' size='small' icon={GearSix} color='ut-black' onClick={handleOpenOptions} />
             </div>
         </footer>
     );

--- a/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
+++ b/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
@@ -32,9 +32,10 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
             {!sidebarOpen && (
                 <Button
                     variant='minimal'
+                    size='small'
                     color='theme-black'
                     onClick={onSidebarToggle}
-                    className='h-fit w-fit screenshot:hidden !p-0'
+                    className='screenshot:hidden'
                     icon={Sidebar}
                 />
             )}

--- a/src/views/components/calendar/CalendarSchedules.tsx
+++ b/src/views/components/calendar/CalendarSchedules.tsx
@@ -26,8 +26,8 @@ export function CalendarSchedules() {
     };
 
     return (
-        <div className='min-w-full w-0 flex flex-col items-center gap-y-spacing-3'>
-            <div className='m0 w-full flex justify-between'>
+        <div className='min-w-full w-0 flex flex-col items-center gap-y-spacing-2'>
+            <div className='m0 w-full flex justify-between items-center'>
                 <Text variant='h3' className='text-nowrap text-theme-black'>
                     MY SCHEDULES
                 </Text>
@@ -35,7 +35,7 @@ export function CalendarSchedules() {
                     variant='minimal'
                     size='small'
                     color='theme-black'
-                    className='btn'
+                    className='!p-0 btn'
                     onClick={handleAddSchedule}
                     icon={Plus}
                 />

--- a/src/views/components/calendar/CalendarSchedules.tsx
+++ b/src/views/components/calendar/CalendarSchedules.tsx
@@ -33,8 +33,9 @@ export function CalendarSchedules() {
                 </Text>
                 <Button
                     variant='minimal'
+                    size='small'
                     color='theme-black'
-                    className='h-fit w-fit !p-0 btn'
+                    className='btn'
                     onClick={handleAddSchedule}
                     icon={Plus}
                 />


### PR DESCRIPTION
Before: the size of the hitbox for most of the sidebar buttons were extremely small:

<img width="1624" alt="Screenshot 2025-03-19 at 12 21 12 AM" src="https://github.com/user-attachments/assets/ed4cd5a0-813d-41bf-adec-a735bff58d34" />


after: changed the size prop to small to make the hitbox area bigger:


<img width="1624" alt="Screenshot 2025-03-19 at 12 21 49 AM" src="https://github.com/user-attachments/assets/7a7bd06d-493f-4750-8610-6cf2523c5ba8" />



DISCLAIMER: the screenshot only shows the sidebar button. All 3 buttons (sidebar, +, settings) have been changed