### PR TITLE
fix(schedule): truncate long schedule names in popup

### DIFF
--- a/src/views/components/common/ScheduleDropdown.tsx
+++ b/src/views/components/common/ScheduleDropdown.tsx
@@ -24,8 +24,12 @@ export default function ScheduleDropdown({ defaultOpen, children }: ScheduleDrop
                 {({ open }) => (
                     <>
                         <DisclosureButton className='w-full flex items-center border-none bg-transparent px-3.5 py-2.5 text-left'>
-                            <div className='flex-1'>
-                                <Text as='div' variant='h3' className='w-100% text-ut-burntorange normal-case!'>
+                            <div className='flex-1 min-w-0 overflow-hidden'>
+                                <Text
+                                    as='div'
+                                    variant='h3'
+                                    className='w-full truncate whitespace-nowrap text-ut-burntorange normal-case!'
+                                >
                                     {activeSchedule ? activeSchedule.name : 'Schedule'}
                                 </Text>
                                 <div className='flex gap-2.5 text-theme-black leading-[75%]!'>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/293bad49-16dc-49db-ba97-e8883a5894e9)

After:
![image](https://github.com/user-attachments/assets/a73a563b-0d01-4f54-8862-0adda0a3ff89)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/564)
<!-- Reviewable:end -->
