### PR TITLE
test: fix flaky sleep test

### DIFF
--- a/src/shared/util/tests/time.test.ts
+++ b/src/shared/util/tests/time.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from 'vitest';
 
 describe('sleep', () => {
     it('should resolve after the specified number of milliseconds', async () => {
-        const start = Date.now();
+        const start = performance.now();
         const milliseconds = 1000;
         await sleep(milliseconds);
-        const end = Date.now();
+        const end = performance.now();
         const elapsed = end - start;
-        expect(elapsed).toBeGreaterThanOrEqual(milliseconds);
+        // Flaky test due to JS's lack of precision in setTimeout,
+        // so we allow for a 1ms difference
+        expect(elapsed).toBeGreaterThanOrEqual(milliseconds - 1);
     });
 });


### PR DESCRIPTION
The existing test failed 11/100 times and 38/1000 times when ran in a loop. Additionally, at least two users have experienced this test case failing when running `pnpm test`.

This is due to JavaScript's event loop and the lack of precision around `setTimeout`.

This PR allows for one millisecond of grace period for that test. Additionally, I switched from `Date.now()` to `performance.now()` to 1. get more accurate errors if this does fail in the future, and 2. not have to deal with edge cases like a system changing its clock while the test is running.

I ran this modified test over 2,000 times and it never failed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/571)
<!-- Reviewable:end -->
