### PR TITLE
chore: setup dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,10 @@ updates:
       directory: '/'
       schedule:
           interval: 'daily'
-      update-types:
-          - 'major'
-      exclude-patterns:
-          - '@crxjs/vite-plugin'
-          - '@unocss/vite'
+      groups:
+          major-updates:
+              update-types:
+                  - 'major'
+              exclude-patterns:
+                  - '@crxjs/vite-plugin'
+                  - '@unocss/vite'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'monday'
+          time: '09:00'
+          timezone: 'America/Chicago'
+      groups:
+          minor-and-patch-updates:
+              update-types:
+                  - 'minor'
+                  - 'patch'
+              exclude-patterns:
+                  - '@crxjs/vite-plugin'
+                  - '@unocss/vite'
+
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'daily'
+          update-types:
+              - 'major'
+          exclude-patterns:
+              - '@crxjs/vite-plugin'
+              - '@unocss/vite'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,8 @@ updates:
       directory: '/'
       schedule:
           interval: 'daily'
-          update-types:
-              - 'major'
-          exclude-patterns:
-              - '@crxjs/vite-plugin'
-              - '@unocss/vite'
+      update-types:
+          - 'major'
+      exclude-patterns:
+          - '@crxjs/vite-plugin'
+          - '@unocss/vite'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,18 +12,10 @@ updates:
               update-types:
                   - 'minor'
                   - 'patch'
-              exclude-patterns:
-                  - '@crxjs/vite-plugin'
-                  - '@unocss/vite'
-
-    - package-ecosystem: 'npm'
-      directory: '/'
-      schedule:
-          interval: 'daily'
-      groups:
           major-updates:
               update-types:
                   - 'major'
-              exclude-patterns:
-                  - '@crxjs/vite-plugin'
-                  - '@unocss/vite'
+
+      ignore:
+         - dependency-name: '@crxjs/vite-plugin'
+         - dependency-name: '@unocss/vite'


### PR DESCRIPTION
Configured dependabot to update all non-patched (i.e. not crxjs and unocss) dependencies, in two groupings:

- Minor/patches (hopefully easy to merge PR)
- Just major updates (might cause build to fail)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/603)
<!-- Reviewable:end -->
