### PR TITLE
fix: hide sentry instrumentation on debug builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,9 +35,13 @@ function removeExtraDatabaseDir(cb) {
 // Instrument with Sentry
 // Make sure sentry is configured https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/typescript/#2-configure-sentry-cli
 async function instrumentWithSentry(cb) {
-    await exec(`sentry-cli sourcemaps inject ${DIST_DIR}`);
-    await exec(`sentry-cli sourcemaps upload ${DIST_DIR}`);
-    log('Sentry instrumentation completed.');
+    if (process.env.SENTRY_ENV && process.env.SENTRY_ENV !== 'development') {
+        await exec(`sentry-cli sourcemaps inject ${DIST_DIR}`);
+        await exec(`sentry-cli sourcemaps upload ${DIST_DIR}`);
+        log('Sentry instrumentation completed.');
+    } else {
+        logWarn('Skipping uploading/creating Sentry source maps. (development build)');
+    }
 
     cb();
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",
+        "build:dev": "tsc && NODE_ENV='development' vite build --mode development",
         "build:watch": "NODE_ENV='development' vite build --mode development -w",
-        "zip": "PROD=true pnpm build && pnpm gulp zipProdBuild",
+        "zip": "pnpm build && pnpm gulp zipProdBuild",
+        "zip:to-publish": "SENTRY_ENV='production' pnpm zip",
         "prettier": "prettier src --check",
         "prettier:fix": "prettier src --write",
         "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ if (isBeta) {
 }
 process.env.VITE_PACKAGE_VERSION = packageJson.version;
 
-// special condition for production sentry instrumentation, as many of our devs like to use `pnpm build` directly. Production instrumentation is added and uploaded during `pnpm zip`.
+// special condition for production sentry instrumentation, as many of our devs like to use `pnpm build` directly. Production instrumentation is added and uploaded during `pnpm zip:to-publish`.
 if (process.env.SENTRY_ENV === 'production') {
     process.env.VITE_SENTRY_ENVIRONMENT = 'production';
 } else if (isBeta) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,16 +24,14 @@ const pagesDir = resolve(root, 'pages');
 const assetsDir = resolve(root, 'assets');
 const publicDir = resolve(__dirname, 'public');
 
-// Set default environment variables
-process.env.PROD = process.env.NODE_ENV === 'production' ? 'true' : 'false';
-
 const isBeta = !!process.env.BETA;
 if (isBeta) {
     process.env.VITE_BETA_BUILD = 'true';
 }
 process.env.VITE_PACKAGE_VERSION = packageJson.version;
-// TODO: Debug this. If PROD is false, VITE_SENTRY_ENVIRONMENT is in production mode
-if (process.env.PROD) {
+
+// special condition for production sentry instrumentation, as many of our devs like to use `pnpm build` directly. Production instrumentation is added and uploaded during `pnpm zip`.
+if (process.env.SENTRY_ENV === 'production') {
     process.env.VITE_SENTRY_ENVIRONMENT = 'production';
 } else if (isBeta) {
     process.env.VITE_SENTRY_ENVIRONMENT = 'beta';


### PR DESCRIPTION
When a build is produced through `pnpm build`, Sentry instrumentation considers that build to be a production build, causing our sentry logs to fill up with development spam.

This should fix that, as Sentry should now consider these builds to be development builds, unless they are built with `SENTRY_ENV=production` environment variable.

To that end, I've added a new script command for when we need to actually publish a new version:

- `pnpm zip:to-public`: zips and includes/uploads Sentry instrumentation, and is given the context of production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/604)
<!-- Reviewable:end -->
