### PR TITLE
chore(ui): added spring 2026 course schedule

### DIFF
--- a/src/views/components/calendar/ResourceLinks.tsx
+++ b/src/views/components/calendar/ResourceLinks.tsx
@@ -15,6 +15,10 @@ interface LinkItem {
 
 const links: LinkItem[] = [
     {
+        text: "Spring '26 Course Schedule",
+        url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20262/',
+    },
+    {
         text: "Fall '25 Course Schedule",
         url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20259/',
     },
@@ -22,10 +26,6 @@ const links: LinkItem[] = [
         text: "Summer '25 Course Schedule",
         url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20256/',
     },
-    // {
-    //     text: "Spring '25 Course Schedule",
-    //     url: 'https://utdirect.utexas.edu/apps/registrar/course_schedule/20252/',
-    // },
     {
         text: 'Course Schedule Archives',
         url: 'https://registrar.utexas.edu/schedules/archive',
@@ -34,10 +34,10 @@ const links: LinkItem[] = [
         text: 'My Degree Audit (IDA)',
         url: 'https://utdirect.utexas.edu/apps/degree/audits/',
     },
-    // {
-    //     text: "'24-'25 Academic Calendar",
-    //     url: 'https://registrar.utexas.edu/calendars/24-25',
-    // },
+    {
+        text: "'25-'26 Academic Calendar",
+        url: 'https://registrar.utexas.edu/calendars/25-26',
+    },
     {
         text: 'Registration Info Sheet (RIS)',
         url: 'https://utdirect.utexas.edu/registrar/ris.WBX',


### PR DESCRIPTION
added link to the spring 2026 course schedule (alongside the previous fall 2025 and summer 2025 that were already there)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/628)
<!-- Reviewable:end -->
