### PR TITLE
fix: whitespace wrapping in semester warning

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -175,12 +175,12 @@ export default function HeadingAndActions({ course, activeSchedule, onClose }: H
                     description: (
                         <>
                             The section you&apos;re adding is for{' '}
-                            <span className='text-ut-burntorange'>
+                            <span className='text-ut-burntorange whitespace-nowrap'>
                                 {course.semester.season} {course.semester.year}
                             </span>
                             , but your current schedule contains sections in{' '}
-                            <span className='text-ut-burntorange'>{activeSemesters}</span>. Mixing semesters in one
-                            schedule may cause confusion.
+                            <span className='text-ut-burntorange whitespace-nowrap'>{activeSemesters}</span>. Mixing
+                            semesters in one schedule may cause confusion.
                         </>
                     ),
                     buttons: dialogButtons,


### PR DESCRIPTION
Before:
<img width="928" height="580" alt="image" src="https://github.com/user-attachments/assets/5a3b3ab7-b107-48d9-8ef5-c06c92df6fbf" />

After:
<img width="448" height="267" alt="image" src="https://github.com/user-attachments/assets/b6bf0e13-c168-4135-89a5-c4529aaf28af" />

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/629)
<!-- Reviewable:end -->
