### PR TITLE
fix: overflow on calendar title has an annoying scrollbar 

### DIFF
--- a/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
+++ b/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
@@ -28,7 +28,7 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
     return (
         <div
             style={{ scrollbarGutter: 'stable' }}
-            className='sticky left-0 right-0 top-0 z-10 min-h-[85px] flex items-center gap-5 overflow-x-scroll overflow-y-hidden bg-white pl-spacing-7 pt-spacing-5'
+            className='sticky left-0 right-0 top-0 z-10 min-h-[85px] flex items-center gap-5 overflow-x-auto overflow-y-hidden bg-white pl-spacing-7 pt-spacing-5'
         >
             {!sidebarOpen && (
                 <Button


### PR DESCRIPTION
It is already truncated so we do not want the scrollbar

<img width="1440" height="900" alt="Screenshot 2025-11-19 at 1 34 07 PM" src="https://github.com/user-attachments/assets/379eba29-191e-42db-8b5f-b119b85a9a35" />

closes #565

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/704)
<!-- Reviewable:end -->
