### PR TITLE
fix: add bottom padding when error fetching grade distribution data

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -221,7 +221,7 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                     }}
                 />
             )}
-            {status === DataStatus.ERROR && <Text variant='p'>Error fetching grade distribution data</Text>}
+            {status === DataStatus.ERROR && <Text variant='p' className='pb-3'>Error fetching grade distribution data</Text>}
             {status === DataStatus.FOUND && (
                 <>
                     <div className='flex flex-wrap content-center items-center self-stretch justify-center gap-3'>


### PR DESCRIPTION
Closes #501.

Added `pb-3` class to the error message Text component to add bottom padding as requested.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/706)
<!-- Reviewable:end -->
