### PR TITLE
feat(nix): add prettier-version-match check

### DIFF
--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -22,5 +22,42 @@
         settings.formatter.shellcheck.excludes = [ ".envrc" ];
         settings.formatter.yamlfmt.excludes = [ "pnpm-lock.yaml" ];
       };
+
+      checks = {
+        prettier-version-match =
+          pkgs.runCommand "check-prettier-version"
+            {
+              buildInputs = [ pkgs.jq ];
+            }
+            ''
+              # Extract prettier version from package.json
+              packageJsonVersion=$(jq -r '.devDependencies.prettier // empty' ${../package.json})
+
+              if [ -z "$packageJsonVersion" ]; then
+                echo "Error: prettier not found in package.json devDependencies"
+                exit 1
+              fi
+
+              # Remove any semver prefix characters (^, ~, etc...)
+              packageJsonVersion=$(echo "$packageJsonVersion" | sed 's/^[\^~>=<]*//')
+
+              # Get prettier version from nixpkgs
+              nixVersion="${pkgs.nodePackages.prettier.version}"
+
+              if [ "$packageJsonVersion" != "$nixVersion" ]; then
+                echo ""
+                echo "ERROR: Prettier version mismatch!"
+                echo "  package.json: $packageJsonVersion"
+                echo "  nixpkgs:      $nixVersion"
+                echo ""
+                echo "Please update one of the following:"
+                echo "  - Update prettier in package.json to match nixpkgs: $nixVersion"
+                echo "  - Override prettier in your flake to match package.json"
+                exit 1
+              fi
+
+              touch $out
+            '';
+      };
     };
 }


### PR DESCRIPTION
Makes sure the prettier version in package.json and the one used by treefmt are the same for consistent results.
This is done via a check in the nix flake (`nix flake check`)

Example error:
<img width="597" height="223" alt="image" src="https://github.com/user-attachments/assets/83c883b7-5fe2-4ef1-ba5a-d4f0327d2732" />


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/713)
<!-- Reviewable:end -->
