### PR TITLE
fix: don't use prefix with local stores

### DIFF
--- a/src/lib/chrome-extension-toolkit/storage/createStore.ts
+++ b/src/lib/chrome-extension-toolkit/storage/createStore.ts
@@ -139,6 +139,10 @@ type StoreOptions = {
      * Whether or not to encrypt the data before storing it, and decrypt it when retrieving it. Defaults to false.
      */
     isEncrypted?: boolean;
+    /**
+     * Whether to use a prefix based on the name of the store, such as "UserScheduleStore:myKey" instead of "myKey". Defaults to true.
+     */
+    usePrefix?: boolean;
 };
 
 const security = new Security();
@@ -156,8 +160,12 @@ function createStore<T>(
     area: 'sync' | 'local' | 'session' | 'managed',
     options?: StoreOptions
 ): Store<T> {
+    const prefix = (options?.usePrefix ?? true) ? `${storeId}:` : '';
+    const makeActualKey = (rawKey: string) => `${prefix}${rawKey}`;
+    const removePrefix = (prefixedKey: string) => prefixedKey.replace(prefix, '');
+
     const keys = Object.keys(defaults) as string[];
-    const actualKeys = keys.map(key => `${storeId}:${key}`);
+    const actualKeys = keys.map(makeActualKey);
 
     let isEncrypted = options?.isEncrypted || false;
 
@@ -181,7 +189,7 @@ function createStore<T>(
 
             for (const key of missingKeys) {
                 // @ts-expect-error
-                const value = defaults[key.replace(`${storeId}:`, '')];
+                const value = defaults[removePrefix(key)];
                 // @ts-expect-error
                 defaultsToSet[key] = isEncrypted ? await security.encrypt(value) : value;
             }
@@ -196,7 +204,7 @@ function createStore<T>(
             await store.initialize();
         }
 
-        const actualKey = `${storeId}:${key}`;
+        const actualKey = makeActualKey(key);
 
         const value = (await chrome.storage[area].get(actualKey))[actualKey];
         return isEncrypted ? await security.decrypt(value) : value;
@@ -213,7 +221,7 @@ function createStore<T>(
             const entriesToSet = {};
 
             for (const [k, v] of Object.entries(key)) {
-                const actualKey = `${storeId}:${k}`;
+                const actualKey = makeActualKey(k);
                 if (v === undefined) {
                     // Prepare to remove this key
                     entriesToRemove.push(actualKey);
@@ -237,7 +245,7 @@ function createStore<T>(
         }
         // now we know key is a string, so lets either set or remove it directly
 
-        const actualKey = `${storeId}:${key}`;
+        const actualKey = makeActualKey(key);
         if (value === undefined) {
             // Remove if value is explicitly undefined
             return await chrome.storage[area].remove(actualKey);
@@ -254,7 +262,7 @@ function createStore<T>(
             await store.initialize();
         }
 
-        const actualKey = `${storeId}:${key}`;
+        const actualKey = makeActualKey(key);
         await chrome.storage[area].remove(actualKey);
     };
 
@@ -266,14 +274,14 @@ function createStore<T>(
         if (isEncrypted) {
             await Promise.all(
                 keys.map(async key => {
-                    const actualKey = `${storeId}:${key}`;
+                    const actualKey = makeActualKey(key);
                     fullStore[key] = await security.decrypt(fullStore[actualKey]);
                 })
             );
         }
-        // now we need to remove the storeId from the keys
+        // now we need to remove the prefix from the keys
         Object.keys(fullStore).forEach(actualKey => {
-            const newKey = actualKey.replace(`${storeId}:`, '');
+            const newKey = removePrefix(actualKey);
             fullStore[newKey] = fullStore[actualKey];
             delete fullStore[actualKey];
         });
@@ -286,7 +294,7 @@ function createStore<T>(
         // @ts-expect-error
         const sub = async (changes, areaName) => {
             const keys = Array.isArray(key) ? key : [key];
-            const actualKeys = keys.map(k => `${storeId}:${k}`);
+            const actualKeys = keys.map(makeActualKey);
 
             if (areaName !== area) return;
 
@@ -295,7 +303,7 @@ function createStore<T>(
             if (!subKeys.length) return;
 
             subKeys.forEach(async actualKey => {
-                const key = actualKey.replace(`${storeId}:`, '');
+                const key = removePrefix(actualKey);
                 const [oldValue, newValue] = await Promise.all([
                     isEncrypted ? security.decrypt(changes[actualKey].oldValue) : changes[actualKey].oldValue,
                     isEncrypted ? security.decrypt(changes[actualKey].newValue) : changes[actualKey].newValue,

--- a/src/shared/storage/CacheStore.ts
+++ b/src/shared/storage/CacheStore.ts
@@ -8,8 +8,14 @@ interface ICacheStore {
 /**
  * A store that is used for storing cached data such as GitHub contributors
  */
-export const CacheStore = createLocalStore<ICacheStore>('CacheStore', {
-    github: {},
-});
+export const CacheStore = createLocalStore<ICacheStore>(
+    'CacheStore',
+    {
+        github: {},
+    },
+    {
+        usePrefix: false,
+    }
+);
 
 // debugStore({ cacheStore: CacheStore });

--- a/src/shared/storage/DevStore.ts
+++ b/src/shared/storage/DevStore.ts
@@ -18,13 +18,19 @@ interface IDevStore {
     reloadTabId?: number;
 }
 
-export const DevStore = createLocalStore<IDevStore>('DevStore', {
-    isDeveloper: false,
-    debugTabId: undefined,
-    isTabReloading: true,
-    wasDebugTabVisible: false,
-    isExtensionReloading: true,
-    reloadTabId: undefined,
-});
+export const DevStore = createLocalStore<IDevStore>(
+    'DevStore',
+    {
+        isDeveloper: false,
+        debugTabId: undefined,
+        isTabReloading: true,
+        wasDebugTabVisible: false,
+        isExtensionReloading: true,
+        reloadTabId: undefined,
+    },
+    {
+        usePrefix: false,
+    }
+);
 
 // debugStore({ devStore: DevStore });

--- a/src/shared/storage/ExtensionStore.ts
+++ b/src/shared/storage/ExtensionStore.ts
@@ -12,10 +12,16 @@ interface IExtensionStore {
     lastWhatsNewPopupVersion: number;
 }
 
-export const ExtensionStore = createLocalStore<IExtensionStore>('ExtensionStore', {
-    version: chrome.runtime.getManifest().version,
-    lastUpdate: Date.now(),
-    lastWhatsNewPopupVersion: 0,
-});
+export const ExtensionStore = createLocalStore<IExtensionStore>(
+    'ExtensionStore',
+    {
+        version: chrome.runtime.getManifest().version,
+        lastUpdate: Date.now(),
+        lastWhatsNewPopupVersion: 0,
+    },
+    {
+        usePrefix: false,
+    }
+);
 
 // debugStore({ ExtensionStore });

--- a/src/shared/storage/OptionsStore.ts
+++ b/src/shared/storage/OptionsStore.ts
@@ -28,16 +28,22 @@ export interface IOptionsStore {
     allowMoreSchedules: boolean;
 }
 
-export const OptionsStore = createSyncStore<IOptionsStore>('OptionsStore', {
-    enableCourseStatusChips: false,
-    enableHighlightConflicts: true,
-    enableScrollToLoad: true,
-    enableDataRefreshing: false,
-    alwaysOpenCalendarInNewTab: false,
-    showCalendarSidebar: true,
-    showUTDiningPromo: true,
-    allowMoreSchedules: false,
-});
+export const OptionsStore = createSyncStore<IOptionsStore>(
+    'OptionsStore',
+    {
+        enableCourseStatusChips: false,
+        enableHighlightConflicts: true,
+        enableScrollToLoad: true,
+        enableDataRefreshing: false,
+        alwaysOpenCalendarInNewTab: false,
+        showCalendarSidebar: true,
+        showUTDiningPromo: true,
+        allowMoreSchedules: false,
+    },
+    {
+        usePrefix: false,
+    }
+);
 
 /**
  * Initializes the settings by retrieving the values from the OptionsStore.

--- a/src/shared/storage/UserScheduleStore.ts
+++ b/src/shared/storage/UserScheduleStore.ts
@@ -11,17 +11,23 @@ interface IUserScheduleStore {
 /**
  * A store that is used for storing user schedules (and the active schedule)
  */
-export const UserScheduleStore = createLocalStore<IUserScheduleStore>('UserScheduleStore', {
-    schedules: [
-        new UserSchedule({
-            courses: [],
-            id: generateRandomId(),
-            name: 'Schedule 1',
-            hours: 0,
-            updatedAt: Date.now(),
-        }),
-    ],
-    activeIndex: 0,
-});
+export const UserScheduleStore = createLocalStore<IUserScheduleStore>(
+    'UserScheduleStore',
+    {
+        schedules: [
+            new UserSchedule({
+                courses: [],
+                id: generateRandomId(),
+                name: 'Schedule 1',
+                hours: 0,
+                updatedAt: Date.now(),
+            }),
+        ],
+        activeIndex: 0,
+    },
+    {
+        usePrefix: false,
+    }
+);
 
 // debugStore({ userScheduleStore: UserScheduleStore });


### PR DESCRIPTION
A new change to chrome extension toolkit made it so that each key has a prefix. But since we have an existing app, users relied on the existing key.

In the future, prefixes may be good, but the complexity of migrating is way more than a simple fix to "ignore" the new prefix feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/760)
<!-- Reviewable:end -->
