### PR TITLE
fix(dialog): remove as={Fragment} from DialogTitle and Description

### DIFF
--- a/src/views/components/common/Dialog.tsx
+++ b/src/views/components/common/Dialog.tsx
@@ -63,8 +63,8 @@ export default function Dialog(props: PropsWithChildren<DialogProps>): JSX.Eleme
                                 className
                             )}
                         >
-                            {title && <DialogTitle as={Fragment}>{title}</DialogTitle>}
-                            {description && <Description as={Fragment}>{description}</Description>}
+                            {title && <DialogTitle>{title}</DialogTitle>}
+                            {description && <Description>{description}</Description>}
                             {children}
                         </DialogPanel>
                     </TransitionChild>


### PR DESCRIPTION
HeadlessUI 2.2.9 requires real DOM elements to attach props (id, data-headlessui-state, data-open). Using as={Fragment} caused a crash when opening dialogs (e.g. duplicating a schedule).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/764)
<!-- Reviewable:end -->
