### PR TITLE
feat: refresh course schedule content daily 

### DIFF
--- a/src/shared/types/UserSchedule.ts
+++ b/src/shared/types/UserSchedule.ts
@@ -15,6 +15,8 @@ export class UserSchedule {
     updatedAt: number;
     /** Unix timestamp of when courses were last checked/refreshed */
     lastCheckedAt?: number | null;
+    /** Unix timestamp of the last failed silent refresh attempt — gates a 60s cooldown before retry */
+    lastAttemptedAt?: number | null;
 
     constructor(schedule: Serialized<UserSchedule>) {
         this.courses = schedule.courses.map(c => new Course(c));
@@ -23,6 +25,7 @@ export class UserSchedule {
         this.hours = this.courses.reduce((acc, c) => acc + c.creditHours, 0);
         this.updatedAt = schedule.updatedAt ?? 0;
         this.lastCheckedAt = schedule.lastCheckedAt ?? null;
+        this.lastAttemptedAt = schedule.lastAttemptedAt ?? null;
     }
 
     containsCourse(course: Course): boolean {

--- a/src/shared/util/checkLoginStatus.ts
+++ b/src/shared/util/checkLoginStatus.ts
@@ -3,15 +3,19 @@ import { UTRP_LOGIN_URL } from '@shared/util/appUrls';
 /**
  * Checks whether the user is logged in to the UT Registrar.
  * If not logged in, opens a new tab to the login page and returns `false`.
+ * When `silent` is true, skips opening the login tab so background refreshes can fail quietly.
  *
+ * @param options.silent when true, suppresses the login tab on 401/403
  * @returns A promise that resolves to `true` if the user is logged in, otherwise `false`.
  */
-export async function validateLoginStatus() {
+export async function validateLoginStatus(options?: { silent?: boolean }) {
     try {
         const response = await fetch(UTRP_LOGIN_URL, { credentials: 'include' });
 
         if (response.redirected || response.status === 401 || response.status === 403) {
-            chrome.tabs.create({ url: UTRP_LOGIN_URL });
+            if (!options?.silent) {
+                chrome.tabs.create({ url: UTRP_LOGIN_URL });
+            }
             return false;
         }
 

--- a/src/views/components/calendar/Calendar.tsx
+++ b/src/views/components/calendar/Calendar.tsx
@@ -112,6 +112,7 @@ export default function Calendar(): ReactNode {
     activeScheduleRef.current = activeSchedule;
 
     // silently refreshes course data when the calendar opens or the active schedule changes
+    // biome-ignore lint/correctness/useExhaustiveDependencies: id is a trigger, not a value read
     useEffect(() => {
         void refreshCourses({ silent: true });
     }, [activeSchedule.id]);

--- a/src/views/components/calendar/Calendar.tsx
+++ b/src/views/components/calendar/Calendar.tsx
@@ -14,6 +14,7 @@ import { CalendarContext } from '@views/contexts/CalendarContext';
 import useCourseFromUrl from '@views/hooks/useCourseFromUrl';
 import { useFlattenedCourseSchedule } from '@views/hooks/useFlattenedCourseSchedule';
 import useReportIssueDialog from '@views/hooks/useReportIssueDialog';
+import refreshCourses from '@views/lib/refreshCourses';
 import clsx from 'clsx';
 import type React from 'react';
 import type { ReactNode } from 'react';
@@ -109,6 +110,11 @@ export default function Calendar(): ReactNode {
 
     const activeScheduleRef = useRef(activeSchedule);
     activeScheduleRef.current = activeSchedule;
+
+    // silently refreshes course data when the calendar opens or the active schedule changes
+    useEffect(() => {
+        void refreshCourses({ silent: true });
+    }, [activeSchedule.id]);
 
     useEffect(() => {
         const listener = new MessageListener<CalendarTabMessages>({

--- a/src/views/lib/refreshCourses.ts
+++ b/src/views/lib/refreshCourses.ts
@@ -25,7 +25,8 @@ function scrapeCourseFromHTML(htmlText: string, url: string): Course | null {
 
 /**
  * Re-scrapes every course in the given schedule and returns updated courses.
- * Preserves user-set properties (colors). Courses that fail to scrape keep their existing data.
+ * Preserves user-set properties (colors). Courses that fail to scrape keep their existing data,
+ * so the returned array holds the same reference identity for each course that was not successfully scraped.
  *
  * Must be called from a page context (not the background service worker) as it relies on DOMParser.
  */
@@ -58,13 +59,19 @@ export async function refreshScheduleCourses(schedule: Serialized<UserSchedule>)
     });
 }
 
+const SILENT_RETRY_COOLDOWN_MS = 60 * 1000;
+
 /**
  * Refreshes all course data for the active schedule.
  * Checks login status first, then scrapes and persists updated data.
+ * When `silent` is true, skips opening the login tab on 401 and applies a 60s cooldown
+ * via `lastAttemptedAt` so repeated mounts do not retry in a tight loop.
  *
- * @returns true if refresh completed, false if login was required
+ * @param options.silent when true, runs the refresh without surfacing login UI
+ * @returns true if refresh completed, false if login was required or the cooldown was active
  */
-export default async function refreshCourses(): Promise<boolean> {
+export default async function refreshCourses(options?: { silent?: boolean }): Promise<boolean> {
+    const silent = options?.silent ?? false;
     const [schedules, activeIndex] = await Promise.all([
         UserScheduleStore.get('schedules'),
         UserScheduleStore.get('activeIndex'),
@@ -75,8 +82,25 @@ export default async function refreshCourses(): Promise<boolean> {
         return true;
     }
 
-    const loggedIn = await validateLoginStatus();
-    if (!loggedIn) return false;
+    if (silent && activeSchedule.lastAttemptedAt != null) {
+        const sinceLastAttempt = Date.now() - activeSchedule.lastAttemptedAt;
+        if (sinceLastAttempt < SILENT_RETRY_COOLDOWN_MS) {
+            return false;
+        }
+    }
+
+    const loggedIn = await validateLoginStatus({ silent });
+    if (!loggedIn) {
+        if (silent) {
+            const updatedSchedules = [...schedules];
+            updatedSchedules[activeIndex] = {
+                ...activeSchedule,
+                lastAttemptedAt: Date.now(),
+            };
+            await UserScheduleStore.set('schedules', updatedSchedules);
+        }
+        return false;
+    }
 
     const updatedCourses = await refreshScheduleCourses(activeSchedule);
 
@@ -86,6 +110,7 @@ export default async function refreshCourses(): Promise<boolean> {
         courses: updatedCourses,
         updatedAt: Date.now(),
         lastCheckedAt: Date.now(),
+        lastAttemptedAt: null,
     };
 
     await UserScheduleStore.set('schedules', updatedSchedules);


### PR DESCRIPTION
This PR address the issue in [UTRP-143](https://linear.app/longhorn-devs/issue/UTRP-143/refresh-active-schedule-daily-when-calendar-is-focused[](url)).

User must be logged into UT Course Schedule webpage and have UTRP Calendar open as their main tab. Course status indicators update if toggled in settings (based on lastCheckedAt). Other information including professors and room changes are also displayed in the Calendar. All updates occur at a maximum of once every 24 hours (depending on when certain conditions are met).


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/789)
<!-- Reviewable:end -->
