### PR TITLE
refactor: migrate phosphor-react icons to unplugin-icons

### DIFF
--- a/nix/pnpm-hash
+++ b/nix/pnpm-hash
@@ -1,1 +1,1 @@
-sha256-a9AHmUQhbqWgsIhnQ/KYnZSVB4Wmzi0LLznpG7roBuA=
+sha256-eR6yIU/jiV2R/lPzIBJ0WIo7tTni4n0xhwCzKL+1aew=

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@headlessui/react": "^2.2.10",
         "@octokit/rest": "^22.0.1",
-        "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",
         "@tanstack/react-query": "^5.96.2",
         "@tsparticles/engine": "^3.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,9 +34,6 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
-      '@phosphor-icons/react':
-        specifier: ^2.1.10
-        version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@sentry/react':
         specifier: ^10.47.0
         version: 10.47.0(react@19.2.4)
@@ -1352,13 +1349,9 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
-  '@phosphor-icons/react@2.1.10':
-    resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: '>= 16.8'
-      react-dom: '>= 16.8'
-
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
     engines: {node: '>=12.22.0'}
@@ -6954,10 +6947,8 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
 
-  '@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@pnpm/config.env-replace@1.1.0': {}
 

--- a/src/shared/util/icons.tsx
+++ b/src/shared/util/icons.tsx
@@ -1,7 +1,9 @@
-import { ClockUser, LockKey, Prohibit } from '@phosphor-icons/react';
 import type { StatusType } from '@shared/types/Course';
 import { Status } from '@shared/types/Course';
 import type { JSX, SVGProps } from 'react';
+import ClockUserFillIcon from '~icons/ph/clock-user-fill';
+import LockKeyFillIcon from '~icons/ph/lock-key-fill';
+import ProhibitFillIcon from '~icons/ph/prohibit-fill';
 
 interface StatusIconProps extends SVGProps<SVGSVGElement> {
     status: StatusType;
@@ -18,11 +20,11 @@ export function StatusIcon(props: StatusIconProps): JSX.Element | null {
 
     switch (status) {
         case Status.WAITLISTED:
-            return <ClockUser weight='fill' {...rest} />;
+            return <ClockUserFillIcon {...rest} />;
         case Status.CLOSED:
-            return <LockKey weight='fill' {...rest} />;
+            return <LockKeyFillIcon {...rest} />;
         case Status.CANCELLED:
-            return <Prohibit weight='fill' {...rest} />;
+            return <ProhibitFillIcon {...rest} />;
         default:
             return null;
     }

--- a/src/stories/components/Button.stories.tsx
+++ b/src/stories/components/Button.stories.tsx
@@ -1,7 +1,13 @@
-import { CalendarDots, ChatText, FileText, ImageSquare, Minus, Plus, Smiley } from '@phosphor-icons/react';
 import { colorsFlattened } from '@shared/util/themeColors';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Button } from '@views/components/common/Button';
+import CalendarDotsIcon from '~icons/ph/calendar-dots';
+import ChatTextIcon from '~icons/ph/chat-text';
+import FileTextIcon from '~icons/ph/file-text';
+import ImageSquareIcon from '~icons/ph/image-square';
+import MinusIcon from '~icons/ph/minus';
+import PlusIcon from '~icons/ph/plus';
+import SmileyIcon from '~icons/ph/smiley';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
@@ -16,7 +22,7 @@ const meta = {
     // More on argTypes: https://storybook.js.org/docs/api/argtypes
     args: {
         children: 'Button',
-        icon: ImageSquare,
+        icon: ImageSquareIcon,
     },
     argTypes: {
         children: { control: 'text' },
@@ -54,9 +60,9 @@ export const Small: Story = {
             </div>
             <hr />
             <div style={{ display: 'flex', gap: '15px' }}>
-                <Button {...props} icon={ImageSquare} variant='filled' color='ut-black' size='small' />
-                <Button {...props} icon={ImageSquare} variant='outline' color='ut-black' size='small' />
-                <Button {...props} icon={ImageSquare} variant='minimal' color='ut-black' size='small' />
+                <Button {...props} icon={ImageSquareIcon} variant='filled' color='ut-black' size='small' />
+                <Button {...props} icon={ImageSquareIcon} variant='outline' color='ut-black' size='small' />
+                <Button {...props} icon={ImageSquareIcon} variant='minimal' color='ut-black' size='small' />
             </div>
         </div>
     ),
@@ -82,9 +88,9 @@ export const Mini: Story = {
             </div>
             <hr />
             <div style={{ display: 'flex', gap: '15px' }}>
-                <Button {...props} icon={ImageSquare} variant='filled' color='ut-black' size='mini' />
-                <Button {...props} icon={ImageSquare} variant='outline' color='ut-black' size='mini' />
-                <Button {...props} icon={ImageSquare} variant='minimal' color='ut-black' size='mini' />
+                <Button {...props} icon={ImageSquareIcon} variant='filled' color='ut-black' size='mini' />
+                <Button {...props} icon={ImageSquareIcon} variant='outline' color='ut-black' size='mini' />
+                <Button {...props} icon={ImageSquareIcon} variant='minimal' color='ut-black' size='mini' />
             </div>
         </div>
     ),
@@ -167,10 +173,10 @@ export const CourseButtons: Story = {
                 alignItems: 'center',
             }}
         >
-            <Button {...props} variant='filled' color='ut-green' icon={Plus}>
+            <Button {...props} variant='filled' color='ut-green' icon={PlusIcon}>
                 Add Course
             </Button>
-            <Button {...props} variant='filled' color='theme-red' icon={Minus}>
+            <Button {...props} variant='filled' color='theme-red' icon={MinusIcon}>
                 Remove Course
             </Button>
         </div>
@@ -190,17 +196,17 @@ export const CourseCatalogActionButtons: Story = {
     },
     render: props => (
         <div style={{ display: 'flex', gap: '15px' }}>
-            <Button {...props} variant='filled' color='ut-burntorange' icon={CalendarDots} />
-            <Button {...props} variant='outline' color='ut-blue' icon={ChatText}>
+            <Button {...props} variant='filled' color='ut-burntorange' icon={CalendarDotsIcon} />
+            <Button {...props} variant='outline' color='ut-blue' icon={ChatTextIcon}>
                 RateMyProf
             </Button>
-            <Button {...props} variant='outline' color='ut-teal' icon={Smiley}>
+            <Button {...props} variant='outline' color='ut-teal' icon={SmileyIcon}>
                 CES
             </Button>
-            <Button {...props} variant='outline' color='ut-orange' icon={FileText}>
+            <Button {...props} variant='outline' color='ut-orange' icon={FileTextIcon}>
                 Past Syllabi
             </Button>
-            <Button {...props} variant='filled' color='ut-green' icon={Plus}>
+            <Button {...props} variant='filled' color='ut-green' icon={PlusIcon}>
                 Add Course
             </Button>
         </div>

--- a/src/stories/components/DialogProvider.stories.tsx
+++ b/src/stories/components/DialogProvider.stories.tsx
@@ -1,9 +1,9 @@
-import { ArrowsVertical } from '@phosphor-icons/react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Button } from '@views/components/common/Button';
 import DialogProvider, { usePrompt } from '@views/components/common/DialogProvider/DialogProvider';
 import Text from '@views/components/common/Text/Text';
 import { useState } from 'react';
+import ArrowsVerticalIcon from '~icons/ph/arrows-vertical';
 
 const meta = {
     title: 'Components/Common/DialogProvider',
@@ -47,7 +47,7 @@ const InnerComponent = () => {
         <Button
             variant='filled'
             color='ut-burntorange'
-            icon={ArrowsVertical}
+            icon={ArrowsVerticalIcon}
             iconProps={{ className: 'h-4 w-4' }}
             onClick={myShow}
         >
@@ -89,7 +89,7 @@ const FiveDialogsInnerComponent = () => {
     };
 
     return (
-        <Button variant='filled' color='ut-burntorange' icon={ArrowsVertical} onClick={myShow}>
+        <Button variant='filled' color='ut-burntorange' icon={ArrowsVerticalIcon} onClick={myShow}>
             Open Dialogs
         </Button>
     );
@@ -123,7 +123,7 @@ const NestedDialogsInnerComponent = () => {
     };
 
     return (
-        <Button variant='filled' color='ut-burntorange' icon={ArrowsVertical} onClick={myShow}>
+        <Button variant='filled' color='ut-burntorange' icon={ArrowsVerticalIcon} onClick={myShow}>
             Open Next Dialog
         </Button>
     );
@@ -162,7 +162,7 @@ const DialogWithOnCloseInnerComponent = () => {
             <h1>
                 You closed the button below {timesClosed} {timesClosed === 1 ? 'time' : 'times'}
             </h1>
-            <Button variant='filled' color='ut-burntorange' icon={ArrowsVertical} onClick={myShow}>
+            <Button variant='filled' color='ut-burntorange' icon={ArrowsVerticalIcon} onClick={myShow}>
                 Open Dialog
             </Button>
         </>

--- a/src/stories/components/Divider.stories.tsx
+++ b/src/stories/components/Divider.stories.tsx
@@ -1,7 +1,11 @@
-import { CalendarDots, ChatText, FileText, Plus, Smiley } from '@phosphor-icons/react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Button } from '@views/components/common/Button';
 import Divider from '@views/components/common/Divider';
+import CalendarDotsIcon from '~icons/ph/calendar-dots';
+import ChatTextIcon from '~icons/ph/chat-text';
+import FileTextIcon from '~icons/ph/file-text';
+import PlusIcon from '~icons/ph/plus';
+import SmileyIcon from '~icons/ph/smiley';
 
 const meta = {
     title: 'Components/Common/Divider',
@@ -54,18 +58,18 @@ export const CourseCatalogActionButtons: Story = {
     },
     render: props => (
         <div className='flex items-center gap-3.75'>
-            <Button variant='filled' color='ut-burntorange' icon={CalendarDots} />
+            <Button variant='filled' color='ut-burntorange' icon={CalendarDotsIcon} />
             <Divider {...props} />
-            <Button variant='outline' color='ut-blue' icon={ChatText}>
+            <Button variant='outline' color='ut-blue' icon={ChatTextIcon}>
                 RateMyProf
             </Button>
-            <Button variant='outline' color='ut-teal' icon={Smiley}>
+            <Button variant='outline' color='ut-teal' icon={SmileyIcon}>
                 CES
             </Button>
-            <Button variant='outline' color='ut-orange' icon={FileText}>
+            <Button variant='outline' color='ut-orange' icon={FileTextIcon}>
                 Past Syllabi
             </Button>
-            <Button variant='filled' color='ut-green' icon={Plus}>
+            <Button variant='filled' color='ut-green' icon={PlusIcon}>
                 Add Course
             </Button>
         </div>

--- a/src/stories/components/FileUpload.stories.tsx
+++ b/src/stories/components/FileUpload.stories.tsx
@@ -1,7 +1,7 @@
-import { ImageSquare } from '@phosphor-icons/react';
 import { colorsFlattened } from '@shared/util/themeColors';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import FileUpload from '@views/components/common/FileUpload';
+import ImageSquareIcon from '~icons/ph/image-square';
 
 /**
  * Stole this straight from Button.stories.tsx to test the input
@@ -15,7 +15,7 @@ const meta = {
     tags: ['autodocs'],
     args: {
         children: 'Upload File',
-        icon: ImageSquare,
+        icon: ImageSquareIcon,
     },
     argTypes: {
         children: { control: 'text' },
@@ -64,9 +64,9 @@ export const Small: Story = {
             </div>
             <hr />
             <div style={{ display: 'flex', gap: '15px' }}>
-                <FileUpload {...props} icon={ImageSquare} variant='filled' color='ut-black' size='small' />
-                <FileUpload {...props} icon={ImageSquare} variant='outline' color='ut-black' size='small' />
-                <FileUpload {...props} icon={ImageSquare} variant='minimal' color='ut-black' size='small' />
+                <FileUpload {...props} icon={ImageSquareIcon} variant='filled' color='ut-black' size='small' />
+                <FileUpload {...props} icon={ImageSquareIcon} variant='outline' color='ut-black' size='small' />
+                <FileUpload {...props} icon={ImageSquareIcon} variant='minimal' color='ut-black' size='small' />
             </div>
         </div>
     ),
@@ -92,9 +92,9 @@ export const Mini: Story = {
             </div>
             <hr />
             <div style={{ display: 'flex', gap: '15px' }}>
-                <FileUpload {...props} icon={ImageSquare} variant='filled' color='ut-black' size='mini' />
-                <FileUpload {...props} icon={ImageSquare} variant='outline' color='ut-black' size='mini' />
-                <FileUpload {...props} icon={ImageSquare} variant='minimal' color='ut-black' size='mini' />
+                <FileUpload {...props} icon={ImageSquareIcon} variant='filled' color='ut-black' size='mini' />
+                <FileUpload {...props} icon={ImageSquareIcon} variant='outline' color='ut-black' size='mini' />
+                <FileUpload {...props} icon={ImageSquareIcon} variant='minimal' color='ut-black' size='mini' />
             </div>
         </div>
     ),

--- a/src/stories/components/Input.stories.tsx
+++ b/src/stories/components/Input.stories.tsx
@@ -1,7 +1,7 @@
-import { ImageSquare } from '@phosphor-icons/react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import Input from '@views/components/common/Input';
 import { type ChangeEvent, type ComponentProps, useState } from 'react';
+import ImageSquareIcon from '~icons/ph/image-square';
 
 const meta = {
     title: 'Components/Common/Input',
@@ -25,7 +25,7 @@ export const Primary: Story = {
     render: (args: ComponentProps<typeof Input>) => <InnerComponent {...args} />,
     args: {
         placeholder: 'Write an input...',
-        icon: ImageSquare,
+        icon: ImageSquareIcon,
         value: '',
     },
 };
@@ -34,7 +34,7 @@ export const Disabled: Story = {
     render: (args: ComponentProps<typeof Input>) => <InnerComponent {...args} />,
     args: {
         placeholder: 'Write an input...',
-        icon: ImageSquare,
+        icon: ImageSquareIcon,
         value: '',
         disabled: true,
     },

--- a/src/stories/components/QuickAddDropdown.stories.tsx
+++ b/src/stories/components/QuickAddDropdown.stories.tsx
@@ -1,7 +1,7 @@
-import { ImageSquare } from '@phosphor-icons/react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import Dropdown from '@views/components/common/Dropdown';
 import React, { type ComponentProps, useState } from 'react';
+import ImageSquareIcon from '~icons/ph/image-square';
 
 const meta = {
     title: 'Components/Common/QuickAddDropdown',
@@ -38,7 +38,7 @@ export const Primary: Story = {
             .fill(null)
             .map((_, i) => ({ id: `${i + 1}`, label: `Option ${i + 1}` })),
         selectedOption: null,
-        icon: ImageSquare,
+        icon: ImageSquareIcon,
         disabled: false,
     },
 };
@@ -53,7 +53,7 @@ export const Disabled: Story = {
             { id: '3', label: 'Option 3' },
         ],
         selectedOption: null,
-        icon: ImageSquare,
+        icon: ImageSquareIcon,
         disabled: true,
     },
 };

--- a/src/views/components/PopupMain.tsx
+++ b/src/views/components/PopupMain.tsx
@@ -1,6 +1,5 @@
 import splashText from '@assets/insideJokes';
 import createSchedule from '@pages/background/lib/createSchedule';
-import { CalendarDots, Flag, GearSix, Plus } from '@phosphor-icons/react';
 import { background } from '@shared/messages';
 import { OptionsStore } from '@shared/storage/OptionsStore';
 import { UserScheduleStore } from '@shared/storage/UserScheduleStore';
@@ -11,6 +10,10 @@ import useReportIssueDialog from '@views/hooks/useReportIssueDialog';
 import useSchedules, { getActiveSchedule, replaceSchedule, switchSchedule } from '@views/hooks/useSchedules';
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
+import CalendarDotsFillIcon from '~icons/ph/calendar-dots-fill';
+import FlagIcon from '~icons/ph/flag';
+import GearSixIcon from '~icons/ph/gear-six';
+import PlusIcon from '~icons/ph/plus';
 
 import { Button } from './common/Button';
 import CourseStatus from './common/CourseStatus';
@@ -78,8 +81,7 @@ export default function PopupMain(): JSX.Element {
                             size='small'
                             color='ut-burntorange'
                             onClick={handleCalendarOpenOnClick}
-                            icon={CalendarDots}
-                            iconProps={{ weight: 'fill' }}
+                            icon={CalendarDotsFillIcon}
                         >
                             Calendar
                         </Button>
@@ -87,7 +89,7 @@ export default function PopupMain(): JSX.Element {
                             variant='minimal'
                             size='small'
                             color='ut-black'
-                            icon={Flag}
+                            icon={FlagIcon}
                             title='Send feedback'
                             onClick={showReportIssueDialog}
                         />
@@ -96,7 +98,7 @@ export default function PopupMain(): JSX.Element {
                             size='small'
                             color='ut-black'
                             onClick={handleOpenOptions}
-                            icon={GearSix}
+                            icon={GearSixIcon}
                         />
                     </div>
                 </div>
@@ -122,7 +124,7 @@ export default function PopupMain(): JSX.Element {
                             size='mini'
                             color='ut-burntorange'
                             onClick={handleAddSchedule}
-                            icon={Plus}
+                            icon={PlusIcon}
                         />
                     </div>
                 </ScheduleDropdown>

--- a/src/views/components/ReportIssueMain.tsx
+++ b/src/views/components/ReportIssueMain.tsx
@@ -1,7 +1,9 @@
-import { X } from '@phosphor-icons/react';
+import 'uno.css';
+
 import { captureFeedback } from '@sentry/react';
 import type { JSX } from 'react';
 import { useState } from 'react';
+import XIcon from '~icons/ph/x';
 
 import { Button } from './common/Button';
 import Input from './common/Input';
@@ -77,7 +79,14 @@ export default function ReportIssueMain({ onClose }: Props): JSX.Element {
                 <Text as='h1' variant='h1' className='text-ut-burntorange'>
                     Longhorn Feedback
                 </Text>
-                <Button variant='minimal' size='small' color='ut-black' icon={X} onClick={handleClose} title='Close' />
+                <Button
+                    variant='minimal'
+                    size='small'
+                    color='ut-black'
+                    icon={XIcon}
+                    onClick={handleClose}
+                    title='Close'
+                />
             </div>
             <Text variant='p' as='p' className='text-ut-black mt-1.5'>
                 Help us make UT Registration Plus even better!

--- a/src/views/components/calendar/Calendar.tsx
+++ b/src/views/components/calendar/Calendar.tsx
@@ -1,6 +1,5 @@
 import { MessageListener } from '@chrome-extension-toolkit';
 import importSchedule from '@pages/background/lib/importSchedule';
-import { Sidebar } from '@phosphor-icons/react';
 import type { CalendarTabMessages } from '@shared/messages/CalendarMessages';
 import { OptionsStore } from '@shared/storage/OptionsStore';
 import type { Course } from '@shared/types/Course';
@@ -20,6 +19,7 @@ import type React from 'react';
 import type { ReactNode } from 'react';
 import { memo, useEffect, useRef, useState } from 'react';
 import OutwardArrowIcon from '~icons/material-symbols/arrow-outward';
+import SidebarIcon from '~icons/ph/sidebar';
 
 import { Button } from '../common/Button';
 import { LargeLogo } from '../common/LogoIcon';
@@ -64,7 +64,7 @@ const CalendarSidebar = memo(function CalendarSidebar() {
                     color='theme-black'
                     onClick={toggleSidebar}
                     className='screenshot:hidden'
-                    icon={Sidebar}
+                    icon={SidebarIcon}
                 />
             </div>
 

--- a/src/views/components/calendar/CalendarCourseCell.tsx
+++ b/src/views/components/calendar/CalendarCourseCell.tsx
@@ -1,4 +1,3 @@
-import { ClockUser, LockKey, Palette, Prohibit } from '@phosphor-icons/react';
 import { OptionsStore } from '@shared/storage/OptionsStore';
 import type { StatusType } from '@shared/types/Course';
 import { Status } from '@shared/types/Course';
@@ -9,6 +8,10 @@ import type { CalendarGridCourse } from '@views/hooks/useFlattenedCourseSchedule
 import clsx from 'clsx';
 import type React from 'react';
 import { useEffect, useRef } from 'react';
+import ClockUserFillIcon from '~icons/ph/clock-user-fill';
+import LockKeyFillIcon from '~icons/ph/lock-key-fill';
+import PaletteFillIcon from '~icons/ph/palette-fill';
+import ProhibitFillIcon from '~icons/ph/prohibit-fill';
 
 import { Button } from '../common/Button';
 import CourseCellColorPicker from './CalendarCourseCellColorPicker/CourseCellColorPicker';
@@ -82,11 +85,11 @@ export default function CalendarCourseCell({
     let rightIcon: React.ReactNode | null = null;
     if (enableCourseStatusChips) {
         if (status === Status.WAITLISTED) {
-            rightIcon = <ClockUser weight='fill' className='h-5 w-5' />;
+            rightIcon = <ClockUserFillIcon className='h-5 w-5' />;
         } else if (status === Status.CLOSED) {
-            rightIcon = <LockKey weight='fill' className='h-5 w-5' />;
+            rightIcon = <LockKeyFillIcon className='h-5 w-5' />;
         } else if (status === Status.CANCELLED) {
-            rightIcon = <Prohibit weight='fill' className='h-5 w-5' />;
+            rightIcon = <ProhibitFillIcon className='h-5 w-5' />;
         }
     }
 
@@ -165,10 +168,9 @@ export default function CalendarCourseCell({
                                 setSelectedCourse(courseID, dayIndex, startIndex);
                             }
                         }}
-                        icon={Palette}
+                        icon={PaletteFillIcon}
                         iconProps={{
                             fill: colors.secondaryColor,
-                            weight: 'fill',
                         }}
                         variant='outline'
                         className={clsx(

--- a/src/views/components/calendar/CalendarCourseCellColorPicker/ColorPatch.tsx
+++ b/src/views/components/calendar/CalendarCourseCellColorPicker/ColorPatch.tsx
@@ -1,6 +1,6 @@
-import { Check } from '@phosphor-icons/react';
 import { useColorPickerContext } from '@views/contexts/ColorPickerContext';
 import type { JSX } from 'react';
+import CheckIcon from '~icons/ph/check';
 
 /**
  * Props for the ColorPatch component
@@ -43,7 +43,7 @@ export default function ColorPatch({
             style={{ backgroundColor: color }}
             onClick={handleClick}
         >
-            {isSelected && <Check className='h-5 w-5 color-white' />}
+            {isSelected && <CheckIcon className='h-5 w-5 color-white' />}
         </button>
     );
 }

--- a/src/views/components/calendar/CalendarCourseCellColorPicker/HexColorEditor.tsx
+++ b/src/views/components/calendar/CalendarCourseCellColorPicker/HexColorEditor.tsx
@@ -1,9 +1,9 @@
-import { Hash } from '@phosphor-icons/react';
 import { isValidHexColor, pickFontColor } from '@shared/util/colors';
 import { getThemeColorHexByName } from '@shared/util/themeColors';
 import { useDebounce } from '@views/hooks/useDebounce';
 import clsx from 'clsx';
 import React, { useEffect } from 'react';
+import HashIcon from '~icons/ph/hash';
 
 /**
  * Props for the HexColorEditor component
@@ -46,7 +46,7 @@ export default function HexColorEditor({ hexCode, setHexCode }: HexColorEditorPr
                 style={{ backgroundColor: previewColor }}
                 className='h-6.5 w-6.5 flex items-center justify-center rounded-l-1'
             >
-                <Hash className={clsx('h-5 w-5 text-color-white', tagColor)} />
+                <HashIcon className={clsx('h-5 w-5 text-color-white', tagColor)} />
             </div>
             <div className='h-6.5 w-[53px] flex flex-1 items-center justify-center border-b border-r border-t rounded-br rounded-tr p-1.25'>
                 <input

--- a/src/views/components/calendar/CalendarFooter.tsx
+++ b/src/views/components/calendar/CalendarFooter.tsx
@@ -1,6 +1,6 @@
-import { GearSix } from '@phosphor-icons/react';
 import { openTabFromContentScript } from '@views/lib/openNewTabFromContentScript';
 import type React from 'react';
+import GearSixIcon from '~icons/ph/gear-six';
 import GithubIcon from '~icons/ph/github-logo';
 import InstagramIcon from '~icons/ph/instagram-logo';
 import LinkedinIcon from '~icons/ph/linkedin-logo';
@@ -90,7 +90,7 @@ export default function CalendarFooter(): React.JSX.Element {
                 <Button
                     variant='minimal'
                     size='small'
-                    icon={GearSix}
+                    icon={GearSixIcon}
                     title='Settings'
                     color='ut-black'
                     onClick={handleOpenOptions}

--- a/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
+++ b/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
@@ -1,5 +1,4 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
-import { ArrowsClockwise, CalendarDots, Export, FileCode, FilePng, FileText, Sidebar } from '@phosphor-icons/react';
 import { OptionsStore } from '@shared/storage/OptionsStore';
 import styles from '@views/components/calendar/CalendarHeader/CalendarHeader.module.scss';
 import { Button } from '@views/components/common/Button';
@@ -15,6 +14,13 @@ import refreshCourses from '@views/lib/refreshCourses';
 import clsx from 'clsx';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import ArrowsClockwiseIcon from '~icons/ph/arrows-clockwise';
+import CalendarDotsIcon from '~icons/ph/calendar-dots';
+import ExportIcon from '~icons/ph/export';
+import FileCodeIcon from '~icons/ph/file-code';
+import FilePngIcon from '~icons/ph/file-png';
+import FileTextIcon from '~icons/ph/file-text';
+import SidebarIcon from '~icons/ph/sidebar';
 
 import { handleExportJson, saveAsCal, saveAsText, saveCalAsPng } from '../utils';
 
@@ -99,7 +105,7 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
                     color='theme-black'
                     onClick={onSidebarToggle}
                     className='screenshot:hidden'
-                    icon={Sidebar}
+                    icon={SidebarIcon}
                 />
             )}
 
@@ -124,7 +130,7 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
                             color='ut-black'
                             size='small'
                             variant='minimal'
-                            icon={Export}
+                            icon={ExportIcon}
                             className='bg-transparent'
                         >
                             Export
@@ -149,7 +155,7 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
                                 color='ut-black'
                                 size='small'
                                 variant='minimal'
-                                icon={FilePng}
+                                icon={FilePngIcon}
                             >
                                 Save as .png
                             </MenuItem>
@@ -160,7 +166,7 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
                                 color='ut-black'
                                 size='small'
                                 variant='minimal'
-                                icon={CalendarDots}
+                                icon={CalendarDotsIcon}
                             >
                                 Save as .cal
                             </MenuItem>
@@ -171,7 +177,7 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
                                 color='ut-black'
                                 size='small'
                                 variant='minimal'
-                                icon={FileCode}
+                                icon={FileCodeIcon}
                             >
                                 Save as .json
                             </MenuItem>
@@ -182,7 +188,7 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
                                 color='ut-black'
                                 size='small'
                                 variant='minimal'
-                                icon={FileText}
+                                icon={FileTextIcon}
                             >
                                 Save as .txt
                             </MenuItem>
@@ -209,7 +215,7 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
                             color='ut-black'
                             size='small'
                             variant='minimal'
-                            icon={ArrowsClockwise}
+                            icon={ArrowsClockwiseIcon}
                             iconProps={{
                                 className: clsx({
                                     'animate-spin animate-duration-800': isRefreshing,

--- a/src/views/components/calendar/CalendarSchedules.tsx
+++ b/src/views/components/calendar/CalendarSchedules.tsx
@@ -1,5 +1,4 @@
 import createSchedule from '@pages/background/lib/createSchedule';
-import { Plus } from '@phosphor-icons/react';
 import { UserScheduleStore } from '@shared/storage/UserScheduleStore';
 import { Button } from '@views/components/common/Button';
 import ScheduleListItem from '@views/components/common/ScheduleListItem';
@@ -8,6 +7,7 @@ import Text from '@views/components/common/Text/Text';
 import { useEnforceScheduleLimit } from '@views/hooks/useEnforceScheduleLimit';
 import { getActiveSchedule, switchSchedule, useAllSchedules } from '@views/hooks/useSchedules';
 import { memo } from 'react';
+import PlusIcon from '~icons/ph/plus';
 
 /**
  * Renders a component that displays a list of schedules.
@@ -37,7 +37,7 @@ export const CalendarSchedules = memo(function CalendarSchedules() {
                     color='theme-black'
                     className='!p-0 btn'
                     onClick={handleAddSchedule}
-                    icon={Plus}
+                    icon={PlusIcon}
                 />
             </div>
             <div className='w-full flex flex-col'>

--- a/src/views/components/calendar/DiningAppPromo.tsx
+++ b/src/views/components/calendar/DiningAppPromo.tsx
@@ -1,7 +1,9 @@
-import { AppStoreLogo, X as CloseIcon, ForkKnife } from '@phosphor-icons/react';
 import { UT_DINING_APP_STORE_URL } from '@shared/util/appUrls';
 import { Button } from '@views/components/common/Button';
 import Text from '@views/components/common/Text/Text';
+import AppStoreLogoIcon from '~icons/ph/app-store-logo';
+import ForkKnifeIcon from '~icons/ph/fork-knife';
+import CloseIcon from '~icons/ph/x';
 
 interface DiningAppPromoProps {
     onClose: () => void;
@@ -14,7 +16,7 @@ export default function DiningAppPromo({ onClose }: DiningAppPromoProps) {
     return (
         <div className='relative min-w-[16.25rem] w-full flex items-center gap-spacing-3 border border-ut-offwhite/50 rounded p-spacing-4'>
             <div className='flex items-center justify-center'>
-                <ForkKnife className='h-6 w-6 text-ut-black' />
+                <ForkKnifeIcon className='h-6 w-6 text-ut-black' />
             </div>
             <div className='flex flex-col gap-spacing-1'>
                 <Text as='p' variant='small' className='whitespace-normal text-ut-black'>
@@ -41,7 +43,7 @@ export default function DiningAppPromo({ onClose }: DiningAppPromoProps) {
                         aria-label='Download on App Store'
                         className='text-theme-black transition-colors hover:text-ut-burntorange'
                     >
-                        <AppStoreLogo className='h-4.5 w-4.5' />
+                        <AppStoreLogoIcon className='h-4.5 w-4.5' />
                     </a>
                     {/* <a
                         href={UT_DINING_GOOGLE_PLAY_URL}

--- a/src/views/components/calendar/ImportantLinks.tsx
+++ b/src/views/components/calendar/ImportantLinks.tsx
@@ -1,7 +1,7 @@
-import { ArrowUpRight } from '@phosphor-icons/react';
 import Text from '@views/components/common/Text/Text';
 import clsx from 'clsx';
 import type { JSX } from 'react';
+import ArrowUpRightIcon from '~icons/ph/arrow-up-right';
 
 type Props = {
     className?: string;
@@ -60,7 +60,7 @@ export default function ImportantLinks({ className }: Props): JSX.Element {
                     rel='noreferrer'
                 >
                     <Text variant='p'>{link.text}</Text>
-                    <ArrowUpRight className='h-4 w-4' />
+                    <ArrowUpRightIcon className='h-4 w-4' />
                 </a>
             ))}
         </article>

--- a/src/views/components/calendar/TeamLinks.tsx
+++ b/src/views/components/calendar/TeamLinks.tsx
@@ -1,9 +1,9 @@
-import { ArrowUpRight } from '@phosphor-icons/react';
 import { CRX_PAGES } from '@shared/types/CRXPages';
 import Text from '@views/components/common/Text/Text';
 import useReportIssueDialog from '@views/hooks/useReportIssueDialog';
 import clsx from 'clsx';
 import type React from 'react';
+import ArrowUpRightIcon from '~icons/ph/arrow-up-right';
 
 type Props = {
     className?: string;
@@ -64,7 +64,7 @@ export default function TeamLinks({ className }: Props): React.JSX.Element {
                     onClick={event => handleClick(link, event)}
                 >
                     <Text variant='p'>{link.text}</Text>
-                    <ArrowUpRight className='h-4 w-4' />
+                    <ArrowUpRightIcon className='h-4 w-4' />
                 </a>
             ))}
         </article>

--- a/src/views/components/common/Button.tsx
+++ b/src/views/components/common/Button.tsx
@@ -1,4 +1,3 @@
-import type { Icon, IconProps } from '@phosphor-icons/react';
 import type { ThemeColor } from '@shared/types/ThemeColors';
 import { getThemeColorHexByName, getThemeColorRgbByName } from '@shared/util/themeColors';
 import Text from '@views/components/common/Text/Text';
@@ -8,8 +7,8 @@ import React from 'react';
 interface ButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'> {
     variant?: 'filled' | 'outline' | 'minimal';
     size?: 'regular' | 'small' | 'mini';
-    icon?: Icon;
-    iconProps?: IconProps;
+    icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+    iconProps?: React.SVGProps<SVGSVGElement>;
     color: ThemeColor;
 }
 
@@ -48,7 +47,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
                 style={
                     {
                         color: colorHex,
-                        backgroundColor: `rgb(${colorRgb} / var(--un-bg-opacity)`,
+                        backgroundColor: `rgb(${colorRgb} / var(--un-bg-opacity))`,
                         ...style,
                     } satisfies React.CSSProperties
                 }

--- a/src/views/components/common/Dropdown.tsx
+++ b/src/views/components/common/Dropdown.tsx
@@ -1,10 +1,9 @@
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react';
-import type { Icon, IconProps } from '@phosphor-icons/react';
-import { CaretDown } from '@phosphor-icons/react';
 import { ellipsify } from '@shared/util/string';
 import Text from '@views/components/common/Text/Text';
 import clsx from 'clsx';
 import type React from 'react';
+import CaretDownIcon from '~icons/ph/caret-down';
 
 import { ExtensionRootWrapper, styleResetClass } from './ExtensionRoot/ExtensionRoot';
 
@@ -23,8 +22,8 @@ interface Props {
     selectedOption: DropdownOption | null;
     onOptionChange?: (newOption: DropdownOption) => void;
     noOptionsText?: string;
-    icon?: Icon;
-    iconProps?: IconProps;
+    icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+    iconProps?: React.SVGProps<SVGSVGElement>;
     disabled?: boolean;
 }
 
@@ -69,7 +68,7 @@ export default function Dropdown({
                     ) : (
                         placeholderText && <Text className='text-ut-black/50'>{placeholderText}</Text>
                     )}
-                    <CaretDown className='h-5 w-5' />
+                    <CaretDownIcon className='h-5 w-5' />
                 </div>
             </ListboxButton>
             <ListboxOptions

--- a/src/views/components/common/FileUpload.tsx
+++ b/src/views/components/common/FileUpload.tsx
@@ -1,4 +1,3 @@
-import type { Icon, IconProps } from '@phosphor-icons/react';
 import type { MIMETypeValue } from '@shared/types/MIMEType';
 import type { ThemeColor } from '@shared/types/ThemeColors';
 import { getThemeColorHexByName, getThemeColorRgbByName } from '@shared/util/themeColors';
@@ -13,8 +12,8 @@ interface Props {
     variant?: 'filled' | 'outline' | 'minimal';
     size?: 'regular' | 'small' | 'mini';
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-    icon?: Icon;
-    iconProps?: IconProps;
+    icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+    iconProps?: React.SVGProps<SVGSVGElement>;
     disabled?: boolean;
     title?: string;
     color: ThemeColor;

--- a/src/views/components/common/Input.tsx
+++ b/src/views/components/common/Input.tsx
@@ -1,11 +1,10 @@
 import { Input as HInput, type InputProps } from '@headlessui/react';
-import type { Icon, IconProps } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import type { Ref } from 'react';
 
 interface Props extends InputProps {
-    icon?: Icon;
-    iconProps?: IconProps;
+    icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+    iconProps?: React.SVGProps<SVGSVGElement>;
     ref?: Ref<HTMLInputElement>;
 }
 

--- a/src/views/components/common/PopupCourseBlock.tsx
+++ b/src/views/components/common/PopupCourseBlock.tsx
@@ -1,4 +1,3 @@
-import { Check, Copy, DotsSixVertical } from '@phosphor-icons/react';
 import { background } from '@shared/messages';
 import { OptionsStore } from '@shared/storage/OptionsStore';
 import type { Course } from '@shared/types/Course';
@@ -10,6 +9,9 @@ import Text from '@views/components/common/Text/Text';
 import clsx from 'clsx';
 import type React from 'react';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import CheckIcon from '~icons/ph/check';
+import CopyFillIcon from '~icons/ph/copy-fill';
+import DotsSixVerticalBoldIcon from '~icons/ph/dots-six-vertical-bold';
 
 import { Button } from './Button';
 import { SortableListDragHandle } from './SortableListDragHandle';
@@ -119,7 +121,7 @@ export default function PopupCourseBlock({ className, course, colors }: PopupCou
                     }}
                     className='flex cursor-move items-center self-stretch rounded rounded-r-0 px-spacing-2'
                 >
-                    <DotsSixVertical weight='bold' className='h-6 w-6 cursor-move text-white' />
+                    <DotsSixVerticalBoldIcon className='h-6 w-6 cursor-move text-white' />
                 </div>
             ) : (
                 <SortableListDragHandle
@@ -128,7 +130,7 @@ export default function PopupCourseBlock({ className, course, colors }: PopupCou
                     }}
                     className='flex cursor-move items-center self-stretch rounded rounded-r-0 px-spacing-2'
                 >
-                    <DotsSixVertical weight='bold' className='h-6 w-6 cursor-move text-white' />
+                    <DotsSixVerticalBoldIcon className='h-6 w-6 cursor-move text-white' />
                 </SortableListDragHandle>
             )}
             <button
@@ -171,14 +173,13 @@ export default function PopupCourseBlock({ className, course, colors }: PopupCou
                     }}
                 >
                     <div className='relative h-[21px] w-[21px]'>
-                        <Check
+                        <CheckIcon
                             className={clsx(
                                 'absolute size-full inset-0 text-white transition-all duration-250 ease-in-out',
                                 isCopied ? 'opacity-100 scale-100' : 'opacity-0 scale-75'
                             )}
                         />
-                        <Copy
-                            weight='fill'
+                        <CopyFillIcon
                             className={clsx(
                                 'absolute size-full inset-0 text-white transition-all duration-250 ease-in-out select-none',
                                 isCopied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'

--- a/src/views/components/common/QuickAddModal.tsx
+++ b/src/views/components/common/QuickAddModal.tsx
@@ -1,5 +1,4 @@
 import { Popover, PopoverButton, PopoverGroup, PopoverPanel } from '@headlessui/react';
-import { Plus, PlusCircle } from '@phosphor-icons/react';
 import { background } from '@shared/messages';
 import { UNIQUE_ID_LENGTH } from '@shared/types/Course';
 import Text from '@views/components/common/Text/Text';
@@ -7,6 +6,8 @@ import { type CourseResult, useQuickAdd } from '@views/hooks/useQuickAdd';
 import clsx from 'clsx';
 import type { JSX } from 'react';
 import { getActiveSchedule } from 'src/views/hooks/useSchedules';
+import PlusIcon from '~icons/ph/plus';
+import PlusCircleIcon from '~icons/ph/plus-circle';
 import { Button } from './Button';
 import Dropdown from './Dropdown';
 import { ExtensionRootWrapper } from './ExtensionRoot/ExtensionRoot';
@@ -51,7 +52,7 @@ export default function QuickAddModal(): JSX.Element {
                 color='ut-black'
                 size='small'
                 variant='minimal'
-                icon={PlusCircle}
+                icon={PlusCircleIcon}
                 onClick={handleQuickAdd}
                 className='bg-transparent'
             >
@@ -134,7 +135,7 @@ export default function QuickAddModal(): JSX.Element {
                             color={courseResult.status === 'found' ? 'ut-green' : 'ut-gray'}
                             size='regular'
                             variant='filled'
-                            icon={Plus}
+                            icon={PlusIcon}
                             type='submit'
                             disabled={courseResult.status !== 'found'}
                         >

--- a/src/views/components/common/ScheduleDropdown.tsx
+++ b/src/views/components/common/ScheduleDropdown.tsx
@@ -1,8 +1,9 @@
 import { Disclosure, DisclosureButton, DisclosurePanel, Transition } from '@headlessui/react';
-import { CaretDown, CaretUp } from '@phosphor-icons/react';
 import Text from '@views/components/common/Text/Text';
 import { useActiveSchedule } from '@views/hooks/useSchedules';
 import type React from 'react';
+import CaretDownFillIcon from '~icons/ph/caret-down-fill';
+import CaretUpFillIcon from '~icons/ph/caret-up-fill';
 
 /**
  * Props for the Dropdown component.
@@ -49,7 +50,7 @@ export default function ScheduleDropdown({ defaultOpen, children }: ScheduleDrop
                                 </Text>
                             </div>
                             <Text className='text-ut-burntorange text-2xl! font-normal!'>
-                                {open ? <CaretDown weight='fill' /> : <CaretUp weight='fill' />}
+                                {open ? <CaretDownFillIcon /> : <CaretUpFillIcon />}
                             </Text>
                         </DisclosureButton>
 

--- a/src/views/components/common/ScheduleListItem.tsx
+++ b/src/views/components/common/ScheduleListItem.tsx
@@ -2,15 +2,6 @@ import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import deleteSchedule from '@pages/background/lib/deleteSchedule';
 import duplicateSchedule from '@pages/background/lib/duplicateSchedule';
 import renameSchedule from '@pages/background/lib/renameSchedule';
-import {
-    Circle,
-    CopySimple,
-    DotsSixVertical,
-    DotsThree,
-    PencilSimpleLine,
-    RadioButton,
-    Trash,
-} from '@phosphor-icons/react';
 import { background } from '@shared/messages';
 import type { UserSchedule } from '@shared/types/UserSchedule';
 import Text from '@views/components/common/Text/Text';
@@ -19,6 +10,13 @@ import { useIsActiveSchedule } from '@views/hooks/useSchedules';
 import { LONGHORN_DEVELOPERS_ADMINS, LONGHORN_DEVELOPERS_SWE } from '@views/lib/getGitHubStats';
 import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
+import CircleIcon from '~icons/ph/circle';
+import CopySimpleIcon from '~icons/ph/copy-simple';
+import DotsSixVerticalBoldIcon from '~icons/ph/dots-six-vertical-bold';
+import DotsThreeBoldIcon from '~icons/ph/dots-three-bold';
+import PencilSimpleLineIcon from '~icons/ph/pencil-simple-line';
+import RadioButtonFillIcon from '~icons/ph/radio-button-fill';
+import TrashIcon from '~icons/ph/trash';
 
 import { Button } from './Button';
 import { usePrompt } from './DialogProvider/DialogProvider';
@@ -146,7 +144,7 @@ export default function ScheduleListItem({ schedule, onClick }: ScheduleListItem
                     <Button
                         variant='filled'
                         color='theme-red'
-                        icon={Trash}
+                        icon={TrashIcon}
                         onClick={() => {
                             close();
                             deleteSchedule(schedule.id);
@@ -164,16 +162,10 @@ export default function ScheduleListItem({ schedule, onClick }: ScheduleListItem
         <div className='h-7.5 rounded bg-white' tabIndex={-1} onKeyDown={handleKeyDown}>
             <div className='h-full w-full flex cursor-pointer items-center gap-[1px] text-ut-burntorange'>
                 {IS_STORYBOOK ? (
-                    <DotsSixVertical
-                        weight='bold'
-                        className='h-6 w-6 cursor-move text-zinc-300 btn-transition -ml-1.5 hover:text-zinc-400'
-                    />
+                    <DotsSixVerticalBoldIcon className='h-6 w-6 cursor-move text-zinc-300 btn-transition -ml-1.5 hover:text-zinc-400' />
                 ) : (
                     <SortableListDragHandle className='flex cursor-move items-center justify-center rounded-md'>
-                        <DotsSixVertical
-                            weight='bold'
-                            className='h-6 w-6 cursor-move text-zinc-300 btn-transition -ml-1.5 hover:text-zinc-400'
-                        />
+                        <DotsSixVerticalBoldIcon className='h-6 w-6 cursor-move text-zinc-300 btn-transition -ml-1.5 hover:text-zinc-400' />
                     </SortableListDragHandle>
                 )}
                 <div className='group flex flex-1 items-center min-w-0'>
@@ -185,12 +177,9 @@ export default function ScheduleListItem({ schedule, onClick }: ScheduleListItem
                         onClick={(...e) => !isEditing && onClick?.(...e)}
                     >
                         {isActive ? (
-                            <RadioButton
-                                className='inline-block h-7.5 w-7.5 shrink-0 btn-transition group-active/circle:scale-95'
-                                weight='fill'
-                            />
+                            <RadioButtonFillIcon className='inline-block h-7.5 w-7.5 shrink-0 btn-transition group-active/circle:scale-95' />
                         ) : (
-                            <Circle className='inline-block h-7.5 w-7.5 shrink-0 btn-transition group-active/circle:scale-95' />
+                            <CircleIcon className='inline-block h-7.5 w-7.5 shrink-0 btn-transition group-active/circle:scale-95' />
                         )}
                         {isEditing && (
                             <Text
@@ -228,7 +217,7 @@ export default function ScheduleListItem({ schedule, onClick }: ScheduleListItem
                             aria-label='Schedule options'
                             className='opacity-0 h-fit bg-transparent p-0 text-ut-gray btn-transition data-[open]:opacity-100 group-hover:opacity-100 focus:opacity-100 rounded-md'
                         >
-                            <DotsThree weight='bold' className='h-6 w-6' />
+                            <DotsThreeBoldIcon className='h-6 w-6' />
                         </MenuButton>
 
                         <MenuItems
@@ -250,7 +239,7 @@ export default function ScheduleListItem({ schedule, onClick }: ScheduleListItem
                                 color='ut-black'
                                 size='small'
                                 variant='minimal'
-                                icon={PencilSimpleLine}
+                                icon={PencilSimpleLineIcon}
                             >
                                 Rename
                             </MenuItem>
@@ -261,7 +250,7 @@ export default function ScheduleListItem({ schedule, onClick }: ScheduleListItem
                                 color='ut-black'
                                 size='small'
                                 variant='minimal'
-                                icon={CopySimple}
+                                icon={CopySimpleIcon}
                             >
                                 Duplicate
                             </MenuItem>
@@ -272,7 +261,7 @@ export default function ScheduleListItem({ schedule, onClick }: ScheduleListItem
                                 color='theme-red'
                                 size='small'
                                 variant='minimal'
-                                icon={Trash}
+                                icon={TrashIcon}
                             >
                                 Delete Schedule
                             </MenuItem>

--- a/src/views/components/injected/AddAllButton.tsx
+++ b/src/views/components/injected/AddAllButton.tsx
@@ -1,5 +1,4 @@
 import { addCourseByURL } from '@pages/background/lib/addCourseByURL';
-import { ArrowsClockwise, Check } from '@phosphor-icons/react';
 import { background } from '@shared/messages';
 import { Button } from '@views/components/common/Button';
 import ExtensionRoot from '@views/components/common/ExtensionRoot/ExtensionRoot';
@@ -8,6 +7,8 @@ import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import createSchedule from 'src/pages/background/lib/createSchedule';
+import ArrowsClockwiseIcon from '~icons/ph/arrows-clockwise';
+import CheckIcon from '~icons/ph/check';
 
 /**
  * InjectedButton component renders a button that adds courses to UTRP from official MyUT calendar
@@ -74,7 +75,8 @@ export default function InjectedButton(): JSX.Element | null {
               ? 'Imported!'
               : 'Add Courses to UT Registration+';
 
-    const buttonIcon = importStatus === 'loading' ? ArrowsClockwise : importStatus === 'complete' ? Check : undefined;
+    const buttonIcon =
+        importStatus === 'loading' ? ArrowsClockwiseIcon : importStatus === 'complete' ? CheckIcon : undefined;
 
     const buttonIconProps =
         importStatus === 'loading'

--- a/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/HeadingAndActions.tsx
@@ -1,17 +1,5 @@
 import createSchedule from '@pages/background/lib/createSchedule';
 import switchSchedule from '@pages/background/lib/switchSchedule';
-import {
-    ArrowUpRight,
-    CalendarDots,
-    ChatText,
-    Check,
-    Copy,
-    FileText,
-    Minus,
-    Plus,
-    Smiley,
-    X,
-} from '@phosphor-icons/react';
 import { background } from '@shared/messages';
 import type { Course } from '@shared/types/Course';
 import type Instructor from '@shared/types/Instructor';
@@ -27,6 +15,16 @@ import { useCalendar } from '@views/contexts/CalendarContext';
 import clsx from 'clsx';
 import type React from 'react';
 import { useRef, useState } from 'react';
+import ArrowUpRightIcon from '~icons/ph/arrow-up-right';
+import CalendarDotsIcon from '~icons/ph/calendar-dots';
+import ChatTextIcon from '~icons/ph/chat-text';
+import CheckIcon from '~icons/ph/check';
+import CopyIcon from '~icons/ph/copy';
+import FileTextIcon from '~icons/ph/file-text';
+import MinusIcon from '~icons/ph/minus';
+import PlusIcon from '~icons/ph/plus';
+import SmileyIcon from '~icons/ph/smiley';
+import XIcon from '~icons/ph/x';
 
 import DisplayMeetingInfo from './DisplayMeetingInfo';
 
@@ -213,13 +211,13 @@ export default function HeadingAndActions({
                     </Text>
                     <Button color='ut-burntorange' variant='minimal' onClick={handleCopy}>
                         <div className='relative h-5.5 w-5.5'>
-                            <Check
+                            <CheckIcon
                                 className={clsx(
                                     'absolute size-full inset-0 text-ut-burntorange transition-all duration-250 ease-in-out',
                                     isCopied ? 'opacity-100 scale-100' : 'opacity-0 scale-75'
                                 )}
                             />
-                            <Copy
+                            <CopyIcon
                                 className={clsx(
                                     'absolute size-full inset-0 text-ut-burntorange transition-all duration-250 ease-in-out',
                                     isCopied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'
@@ -229,7 +227,7 @@ export default function HeadingAndActions({
                         {formattedUniqueId}
                     </Button>
                     <button type='button' className='bg-transparent p-0 text-ut-black btn' onClick={onClose}>
-                        <X className='h-6 w-6' />
+                        <XIcon className='h-6 w-6' />
                     </button>
                 </div>
                 <div className='flex items-center gap-2'>
@@ -277,7 +275,7 @@ export default function HeadingAndActions({
                 <Button
                     variant='filled'
                     color='ut-burntorange'
-                    icon={isInCalendar ? ArrowUpRight : CalendarDots}
+                    icon={isInCalendar ? ArrowUpRightIcon : CalendarDotsIcon}
                     onClick={() => {
                         if (isInCalendar) {
                             openNewTab({
@@ -292,7 +290,7 @@ export default function HeadingAndActions({
                 <Button
                     variant='outline'
                     color='ut-blue'
-                    icon={ChatText}
+                    icon={ChatTextIcon}
                     onClick={handleOpenRateMyProf}
                     disabled={instructors.length === 0}
                 >
@@ -301,19 +299,19 @@ export default function HeadingAndActions({
                 <Button
                     variant='outline'
                     color='ut-teal'
-                    icon={Smiley}
+                    icon={SmileyIcon}
                     onClick={handleOpenCES}
                     disabled={instructors.length === 0}
                 >
                     CES
                 </Button>
-                <Button variant='outline' color='ut-orange' icon={FileText} onClick={handleOpenPastSyllabi}>
+                <Button variant='outline' color='ut-orange' icon={FileTextIcon} onClick={handleOpenPastSyllabi}>
                     Past Syllabi
                 </Button>
                 <Button
                     variant='filled'
                     color={!courseAdded ? 'ut-green' : 'theme-red'}
-                    icon={!courseAdded ? Plus : Minus}
+                    icon={!courseAdded ? PlusIcon : MinusIcon}
                     onClick={handleAddOrRemoveCourse}
                 >
                     {!courseAdded ? 'Add Course' : 'Remove Course'}

--- a/src/views/components/injected/TableRow/TableRow.tsx
+++ b/src/views/components/injected/TableRow/TableRow.tsx
@@ -1,4 +1,3 @@
-import { ChartBar } from '@phosphor-icons/react';
 import { OptionsStore } from '@shared/storage/OptionsStore';
 import type { Course, ScrapedRow } from '@shared/types/Course';
 import type { UserSchedule } from '@shared/types/UserSchedule';
@@ -7,6 +6,7 @@ import ExtensionRoot from '@views/components/common/ExtensionRoot/ExtensionRoot'
 import type { JSX } from 'react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import ChartBarFillIcon from '~icons/ph/chart-bar-fill';
 
 import styles from './TableRow.module.scss';
 
@@ -114,7 +114,7 @@ export default function TableRow({ row, isSelected, activeSchedule, onClick }: P
                     className='m1 h-6 w-6 flex items-center justify-center rounded bg-ut-burntorange color-white! cursor-pointer'
                     onClick={onClick}
                 >
-                    <ChartBar className='text-ut-white h-4 w-4' weight='fill' />
+                    <ChartBarFillIcon className='text-ut-white h-4 w-4' />
                 </button>
                 {conflicts.length > 0 && (
                     <ConflictsWithWarning

--- a/src/views/components/settings/AdvancedSettings.tsx
+++ b/src/views/components/settings/AdvancedSettings.tsx
@@ -1,4 +1,3 @@
-import { Trash } from '@phosphor-icons/react';
 import { OptionsStore } from '@shared/storage/OptionsStore';
 import MIMEType from '@shared/types/MIMEType';
 import type { UserSchedule } from '@shared/types/UserSchedule';
@@ -9,6 +8,7 @@ import SwitchButton from '@views/components/common/SwitchButton';
 import Text from '@views/components/common/Text/Text';
 import clsx from 'clsx';
 import type React from 'react';
+import TrashIcon from '~icons/ph/trash';
 
 import FileUpload from '../common/FileUpload';
 import { DISPLAY_PREVIEWS, PREVIEW_SECTION_DIV_CLASSNAME } from './constants';
@@ -209,7 +209,7 @@ export const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
                         </Text>
                         <p className='text-sm text-gray-600'>Erases all schedules and courses you have.</p>
                     </div>
-                    <Button variant='outline' color='theme-red' icon={Trash} onClick={handleEraseAll}>
+                    <Button variant='outline' color='theme-red' icon={TrashIcon} onClick={handleEraseAll}>
                         Erase All
                     </Button>
                 </div>

--- a/src/views/components/settings/Settings.tsx
+++ b/src/views/components/settings/Settings.tsx
@@ -2,7 +2,6 @@
 import { addCourseByURL } from '@pages/background/lib/addCourseByURL';
 import { deleteAllSchedules } from '@pages/background/lib/deleteSchedule';
 import importSchedule from '@pages/background/lib/importSchedule';
-import { CalendarDots } from '@phosphor-icons/react';
 // Shared
 import { background } from '@shared/messages';
 import { DevStore } from '@shared/storage/DevStore';
@@ -28,7 +27,7 @@ import {
 // Misc
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-
+import CalendarDotsIcon from '~icons/ph/calendar-dots';
 // Icons
 import GitMergeIcon from '~icons/ph/git-merge';
 
@@ -233,7 +232,7 @@ export default function Settings(): React.JSX.Element {
                     <Button
                         variant='minimal'
                         size='small'
-                        icon={CalendarDots}
+                        icon={CalendarDotsIcon}
                         color='ut-black'
                         title='Open Calendar'
                         onClick={() => background.switchToCalendarTab({})}

--- a/src/views/hooks/useChangelog.tsx
+++ b/src/views/hooks/useChangelog.tsx
@@ -1,7 +1,7 @@
-import { X } from '@phosphor-icons/react';
 import Text from '@views/components/common/Text/Text';
 import { useDialog } from '@views/contexts/DialogContext';
 import { lazy, Suspense } from 'react';
+import XIcon from '~icons/ph/x';
 
 import { Button } from '../components/common/Button';
 
@@ -23,7 +23,7 @@ export default function useChangelog(): () => void {
                         Changelog
                     </Text>
                     <Button variant='minimal' onClick={close} color='theme-black' className='p-1 text-gray-700'>
-                        <X className='h-6 w-6' />
+                        <XIcon className='h-6 w-6' />
                     </Button>
                 </div>
             ),


### PR DESCRIPTION
Move away from `phosphor-react` in favor of using `unplugin-icons` directly, as we originally were.

This lets us use any icons we wish, and inlines svgs rather than relying on React components.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/816)
<!-- Reviewable:end -->
