### PR TITLE
fix: calendar screenshot shadow root and remove padding

### DIFF
--- a/src/lib/chrome-extension-toolkit/dom/createShadowRoot.ts
+++ b/src/lib/chrome-extension-toolkit/dom/createShadowRoot.ts
@@ -31,6 +31,7 @@ export function createShadowDOM(id: string, options?: ShadowRootInit, isolate = 
     div.style.all = 'initial';
     div.attachShadow({
         mode: 'open',
+        clonable: true,
         ...(options || {}),
     });
 

--- a/src/views/components/calendar/Calendar.tsx
+++ b/src/views/components/calendar/Calendar.tsx
@@ -99,7 +99,6 @@ const CalendarSidebar = memo(function CalendarSidebar() {
  */
 export default function Calendar(): ReactNode {
     const { courseCells, activeSchedule, startMinutes, endMinutes } = useFlattenedCourseSchedule();
-    const displayBottomBar = true;
     const initialCourse = useCourseFromUrl();
     const [course, setCourse] = useState<Course | null>(initialCourse);
     const [isPopupOpen, setIsPopupOpen] = useState<boolean>(initialCourse !== null);
@@ -221,6 +220,8 @@ export default function Calendar(): ReactNode {
     };
     // --------------------------------------------------
 
+    const bottomBar = <CalendarBottomBar courseCells={courseCells} setCourse={openCourse} />;
+
     return (
         <CalendarContext.Provider value>
             <div className='relative h-full w-full flex flex-col'>
@@ -268,7 +269,7 @@ export default function Calendar(): ReactNode {
                         <CalendarHeader sidebarOpen={showSidebar} onSidebarToggle={toggleSidebar} />
                         <div
                             className={clsx('min-h-2xl min-w-5xl flex-grow gap-0 pl-spacing-3 screenshot:min-h-xl', {
-                                'screenshot:flex-grow-0': displayBottomBar, // html-to-image seems to have a bug with flex-grow
+                                'screenshot:flex-grow-0': bottomBar !== null, // html-to-image seems to have a bug with flex-grow
                             })}
                         >
                             <CalendarGrid
@@ -278,7 +279,7 @@ export default function Calendar(): ReactNode {
                                 endMinutes={endMinutes}
                             />
                         </div>
-                        <CalendarBottomBar courseCells={courseCells} setCourse={openCourse} />
+                        {bottomBar}
                     </div>
                 </div>
 

--- a/src/views/components/calendar/utils.ts
+++ b/src/views/components/calendar/utils.ts
@@ -23,6 +23,7 @@ import {
 import { toBlob } from 'html-to-image';
 
 import { academicCalendars } from './academic-calendars';
+import { ensureShadowStyles } from '@views/components/common/ExtensionRoot/ShadowRootContainer';
 
 // Do all timezone calculations relative to UT's timezone
 const TIMEZONE_ID = 'America/Chicago';
@@ -348,9 +349,14 @@ export const saveCalAsPng = () => {
 
     const clonedNode = document.querySelector('#root')?.cloneNode(true) as HTMLDivElement;
     clonedNode.style.backgroundColor = 'white';
-    (clonedNode.firstChild as HTMLDivElement).classList.add('screenshot-in-progress');
 
-    const calendarTarget = clonedNode.querySelector('.screenshot\\:calendar-target') as HTMLDivElement;
+    const shadowRoot = clonedNode.querySelector('.shadow-root-container')?.shadowRoot as ShadowRoot;
+    ensureShadowStyles(shadowRoot);
+    for (const node of shadowRoot.children) {
+        node.classList.add('screenshot-in-progress');
+    }
+
+    const calendarTarget = shadowRoot.querySelector('.screenshot\\:calendar-target') as HTMLDivElement;
     calendarTarget.style.width = `${WIDTH_PX}px`;
     calendarTarget.style.height = `${HEIGHT_PX}px`;
 

--- a/src/views/components/calendar/utils.ts
+++ b/src/views/components/calendar/utils.ts
@@ -8,6 +8,7 @@ import Instructor from '@shared/types/Instructor';
 import type { UserSchedule } from '@shared/types/UserSchedule';
 import { downloadBlob } from '@shared/util/downloadBlob';
 import { englishStringifyList } from '@shared/util/string';
+import { ensureShadowStyles } from '@views/components/common/ExtensionRoot/ShadowRootContainer';
 import type { CalendarGridCourse } from '@views/hooks/useFlattenedCourseSchedule';
 import type { DateArg, Day } from 'date-fns';
 import {
@@ -21,9 +22,7 @@ import {
     set as setMultiple,
 } from 'date-fns';
 import { toBlob } from 'html-to-image';
-
 import { academicCalendars } from './academic-calendars';
-import { ensureShadowStyles } from '@views/components/common/ExtensionRoot/ShadowRootContainer';
 
 // Do all timezone calculations relative to UT's timezone
 const TIMEZONE_ID = 'America/Chicago';

--- a/src/views/components/common/ExtensionRoot/ShadowRootContainer.tsx
+++ b/src/views/components/common/ExtensionRoot/ShadowRootContainer.tsx
@@ -8,12 +8,11 @@
 
 import 'virtual:uno.css';
 import globalStyleSheet from 'virtual:inline-styles';
+import clsx from 'clsx';
 import type { Ref } from 'react';
 import React from 'react';
 import { createPortal } from 'react-dom';
-
 import styles from './ExtensionRoot.module.scss';
-import clsx from 'clsx';
 
 /** CSS module class that applies the extension's base font, color, and scrollbar resets. */
 export const styleResetClass = styles.extensionRoot;

--- a/src/views/components/common/ExtensionRoot/ShadowRootContainer.tsx
+++ b/src/views/components/common/ExtensionRoot/ShadowRootContainer.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { createPortal } from 'react-dom';
 
 import styles from './ExtensionRoot.module.scss';
+import clsx from 'clsx';
 
 /** CSS module class that applies the extension's base font, color, and scrollbar resets. */
 export const styleResetClass = styles.extensionRoot;
@@ -31,7 +32,7 @@ function assignRef<T>(ref: Ref<T> | undefined, value: T | null) {
 }
 
 /** Adopts the global CSSStyleSheet into a shadow root exactly once. */
-function ensureShadowStyles(shadowRoot: ShadowRoot) {
+export function ensureShadowStyles(shadowRoot: ShadowRoot) {
     if (styledShadowRoots.has(shadowRoot)) {
         return;
     }
@@ -64,7 +65,7 @@ export default function ShadowRootContainer({
                 return;
             }
 
-            const root = node.shadowRoot ?? node.attachShadow({ mode: 'open' });
+            const root = node.shadowRoot ?? node.attachShadow({ mode: 'open', clonable: true });
             ensureShadowStyles(root);
             setShadowRoot(root);
         },
@@ -72,7 +73,7 @@ export default function ShadowRootContainer({
     );
 
     return (
-        <div className={className} {...props} ref={setHostRef}>
+        <div className={clsx(className, 'shadow-root-container')} {...props} ref={setHostRef}>
             {shadowRoot && createPortal(<div className={styleResetClass}>{children}</div>, shadowRoot)}
         </div>
     );


### PR DESCRIPTION
Fixed "save as png" functionality on the calendar page, due to a regression from https://github.com/Longhorn-Developers/UT-Registration-Plus/commit/43b055836490fe3cc49b53bb865534e7688be046.

Also fixed the padding at the bottom, due to some change forcing the bottom bar to be treated as always shown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/865)
<!-- Reviewable:end -->
