### PR TITLE
feat: display buildings in UTRP Map with hosted courses highlighted

### DIFF
--- a/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
+++ b/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
@@ -1,5 +1,7 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import { background } from '@shared/messages';
 import { OptionsStore } from '@shared/storage/OptionsStore';
+import { CRX_PAGES } from '@shared/types/CRXPages';
 import styles from '@views/components/calendar/CalendarHeader/CalendarHeader.module.scss';
 import { Button } from '@views/components/common/Button';
 import Divider from '@views/components/common/Divider';
@@ -20,6 +22,7 @@ import ExportIcon from '~icons/ph/export';
 import FileCodeIcon from '~icons/ph/file-code';
 import FilePngIcon from '~icons/ph/file-png';
 import FileTextIcon from '~icons/ph/file-text';
+import MapPinAreaIcon from '~icons/ph/map-pin-area';
 import SidebarIcon from '~icons/ph/sidebar';
 
 import { handleExportJson, saveAsCal, saveAsText, saveCalAsPng } from '../utils';
@@ -42,9 +45,16 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
     const enableDataRefreshing = OptionsStore.useStore(store => store.enableDataRefreshing);
 
     const isCooldown = cooldownIds.has(activeSchedule.id);
-    const hasRightHandSide = enableDataRefreshing;
+    // UTRP Map button is always present, so the right-hand-side divider should always render
+    const hasRightHandSide = true;
     const isRefreshingRef = useRef(false);
     isRefreshingRef.current = isRefreshing;
+
+    // Open the UTRP Map in a new tab so highlights can render against the active schedule
+    const handleOpenMap = useCallback(() => {
+        const mapPageUrl = chrome.runtime.getURL(CRX_PAGES.MAP);
+        background.openNewTab({ url: mapPageUrl });
+    }, []);
 
     const handleRefresh = useCallback(async () => {
         setIsRefreshing(true);
@@ -206,6 +216,15 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
                 </div>
                 {hasRightHandSide && <Divider className='self-center' size='1.75rem' orientation='vertical' />}
                 <div className={clsx(styles.secondaryActions, 'flex items-center gap-3 ml-auto')}>
+                    <Button
+                        color='ut-black'
+                        size='small'
+                        variant='minimal'
+                        icon={MapPinAreaIcon}
+                        onClick={handleOpenMap}
+                    >
+                        UTRP Map
+                    </Button>
                     {enableDataRefreshing && lastCheckedText && (
                         <Text variant='mini' className='whitespace-nowrap text-theme-black/50 !font-normal'>
                             Last checked: {lastCheckedText}

--- a/src/views/components/common/ExtensionRoot/ExtensionRoot.tsx
+++ b/src/views/components/common/ExtensionRoot/ExtensionRoot.tsx
@@ -1,4 +1,4 @@
-// biome-ignore assist/source/organizeImports: react-scan must be imported before React and React DOM
+// biome-ignore-all assist/source/organizeImports: react-scan must be imported before React and React DOM
 import { scan } from 'react-scan';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/src/views/components/map/CampusMap.tsx
+++ b/src/views/components/map/CampusMap.tsx
@@ -35,6 +35,8 @@ type SelectedBuildings = {
 
 type CampusMapProps = {
     processedCourses: ProcessInPersonMeetings[];
+    /** Building IDs (e.g. 'GDC') to highlight yellow for the active schedule. Empty if no schedule. */
+    highlightedBuildings?: string[];
 };
 
 /**
@@ -58,7 +60,9 @@ type CampusMapProps = {
  * - Dev controls for toggling element visibility.
  * - Zoom and pan controls.
  */
-export default function CampusMap({ processedCourses }: CampusMapProps): React.JSX.Element {
+export default function CampusMap({ processedCourses, highlightedBuildings = [] }: CampusMapProps): React.JSX.Element {
+    // Set lookup for O(1) building-id-in-active-schedule checks in the render loop
+    const highlightedBuildingSet = useMemo(() => new Set(highlightedBuildings), [highlightedBuildings]);
     // Core state
     const [selected, setSelected] = useState<SelectedBuildings>({
         start: null,
@@ -626,11 +630,13 @@ export default function CampusMap({ processedCourses }: CampusMapProps): React.J
                                                 ? '#579D42'
                                                 : id === selected.end
                                                   ? '#D10000'
-                                                  : node.type === 'building'
-                                                    ? '#BF5700'
-                                                    : node.type === 'intersection'
-                                                      ? '#9CADB7'
-                                                      : '#D6D2C400'
+                                                  : node.type === 'building' && highlightedBuildingSet.has(id)
+                                                    ? '#FFD700'
+                                                    : node.type === 'building'
+                                                      ? '#BF5700'
+                                                      : node.type === 'intersection'
+                                                        ? '#9CADB7'
+                                                        : '#D6D2C400'
                                         }
                                         stroke={node.type !== 'walkway' ? 'white' : 'green'}
                                         strokeWidth={zoomLevel < ZOOM_LEVELS.MEDIUM ? '1.5' : '2'}

--- a/src/views/components/map/CampusMap.tsx
+++ b/src/views/components/map/CampusMap.tsx
@@ -203,7 +203,9 @@ export default function CampusMap({ processedCourses, highlightedBuildings = [] 
         });
 
         // Always render active-schedule buildings, regardless of zoom-level clustering
-        highlightedBuildingSet.forEach(id => result.add(id));
+        for (const id of highlightedBuildingSet) {
+            result.add(id);
+        }
 
         return result;
     }, [selected.start, selected.end, relevantPaths, highlightedBuildingSet]);
@@ -623,7 +625,6 @@ export default function CampusMap({ processedCourses, highlightedBuildings = [] 
                         ([id, node]) =>
                             shouldShowNode(node.type, id) && (
                                 <g key={id}>
-                                    {/** biome-ignore lint/a11y/noStaticElementInteractions: TODO: */}
                                     {/* Larger semi-transparent yellow halo behind highlighted building circles */}
                                     {node.type === 'building' && highlightedBuildingSet.has(id) && (
                                         <circle
@@ -638,6 +639,7 @@ export default function CampusMap({ processedCourses, highlightedBuildings = [] 
                                             pointerEvents='none'
                                         />
                                     )}
+                                    {/** biome-ignore lint/a11y/noStaticElementInteractions: TODO: */}
                                     <circle
                                         cx={node.x}
                                         cy={node.y}

--- a/src/views/components/map/CampusMap.tsx
+++ b/src/views/components/map/CampusMap.tsx
@@ -202,8 +202,11 @@ export default function CampusMap({ processedCourses, highlightedBuildings = [] 
             result.add(path.end);
         });
 
+        // Always render active-schedule buildings, regardless of zoom-level clustering
+        highlightedBuildingSet.forEach(id => result.add(id));
+
         return result;
-    }, [selected.start, selected.end, relevantPaths]);
+    }, [selected.start, selected.end, relevantPaths, highlightedBuildingSet]);
 
     // Memoized set of buildings to show based on zoom level and grid clustering
     const visibleBuildings = useMemo(() => {
@@ -621,6 +624,20 @@ export default function CampusMap({ processedCourses, highlightedBuildings = [] 
                             shouldShowNode(node.type, id) && (
                                 <g key={id}>
                                     {/** biome-ignore lint/a11y/noStaticElementInteractions: TODO: */}
+                                    {/* Larger semi-transparent yellow halo behind highlighted building circles */}
+                                    {node.type === 'building' && highlightedBuildingSet.has(id) && (
+                                        <circle
+                                            cx={node.x}
+                                            cy={node.y}
+                                            r={getNodeSize(node.type) * 2.1}
+                                            fill='#FFD700'
+                                            fillOpacity={0.55}
+                                            stroke='#FFD700'
+                                            strokeOpacity={0.9}
+                                            strokeWidth='1.5'
+                                            pointerEvents='none'
+                                        />
+                                    )}
                                     <circle
                                         cx={node.x}
                                         cy={node.y}

--- a/src/views/components/map/Map.tsx
+++ b/src/views/components/map/Map.tsx
@@ -184,11 +184,16 @@ export default function UTRPMap(): JSX.Element {
 
     // Derive unique on-campus buildings to highlight from the active schedule
     const highlightedBuildings = useMemo<string[]>(() => {
-        const ids = activeSchedule.courses
+        const rawBuildings = activeSchedule.courses
             .flatMap(course => course.schedule.meetings)
-            .map(meeting => meeting.location?.building)
-            .filter((b): b is string => !!b && !NON_PHYSICAL_BUILDINGS.has(b.toUpperCase()));
-        return [...new Set(ids)];
+            .map(meeting => meeting.location?.building);
+        const ids = rawBuildings
+            .filter((b): b is string => !!b && !NON_PHYSICAL_BUILDINGS.has(b.toUpperCase()))
+            .map(b => b.toUpperCase());
+        const unique = [...new Set(ids)];
+        // TODO: remove after verifying yellow render
+        console.log('[utrp-highlight] raw:', rawBuildings, 'unique:', unique);
+        return unique;
     }, [activeSchedule]);
 
     const generateWeekSchedule = useCallback((): Record<DAY, string[]> => {
@@ -278,8 +283,31 @@ export default function UTRPMap(): JSX.Element {
                     <CampusMap processedCourses={processedCourses} highlightedBuildings={highlightedBuildings} />
                 </div>
 
-                {/* Show week schedule */}
                 <div className='flex flex-col py-12'>
+                    {/* Map legend */}
+                    <div className='flex flex-col pb-8'>
+                        <p className='text-lg font-medium'>Legend:</p>
+                        <div className='flex flex-col pb-4'>
+                            <p className='text-sm font-medium'>Active Schedule</p>
+                            <div className='flex items-center gap-2 text-xs'>
+                                <svg width='14' height='14' aria-hidden='true'>
+                                    <circle
+                                        cx='7'
+                                        cy='7'
+                                        r='6'
+                                        fill='#FFD700'
+                                        fillOpacity={0.55}
+                                        stroke='#FFD700'
+                                        strokeWidth='1'
+                                    />
+                                    <circle cx='7' cy='7' r='3' fill='#FFD700' stroke='white' strokeWidth='1' />
+                                </svg>
+                                Buildings hosting courses in your active schedule
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Show week schedule */}
                     <p className='text-lg font-medium'>Week Schedule:</p>
                     {Object.entries(generateWeekSchedule()).map(([day, courses]) => (
                         <div key={day} className='flex flex-col pb-4'>

--- a/src/views/components/map/Map.tsx
+++ b/src/views/components/map/Map.tsx
@@ -7,7 +7,7 @@ import Text from '@views/components/common/Text/Text';
 import useChangelog from '@views/hooks/useChangelog';
 import { useActiveSchedule } from '@views/hooks/useSchedules';
 import type { JSX } from 'react';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import IconoirGitFork from '~icons/iconoir/git-fork';
 
@@ -20,6 +20,9 @@ import { type DAY, DAYS } from './types';
 
 const manifest = chrome.runtime.getManifest();
 const LDIconURL = new URL('/src/assets/LD-icon.png', import.meta.url).href;
+
+// Building codes that don't correspond to a physical campus location
+const NON_PHYSICAL_BUILDINGS = new Set(['TBA', 'ONL', 'INTERNET', '']);
 
 const dayToNumber = {
     Monday: 0,
@@ -179,6 +182,15 @@ export default function UTRPMap(): JSX.Element {
         );
     });
 
+    // Derive unique on-campus buildings to highlight from the active schedule
+    const highlightedBuildings = useMemo<string[]>(() => {
+        const ids = activeSchedule.courses
+            .flatMap(course => course.schedule.meetings)
+            .map(meeting => meeting.location?.building)
+            .filter((b): b is string => !!b && !NON_PHYSICAL_BUILDINGS.has(b.toUpperCase()));
+        return [...new Set(ids)];
+    }, [activeSchedule]);
+
     const generateWeekSchedule = useCallback((): Record<DAY, string[]> => {
         const weekSchedule: Record<string, string[]> = {};
 
@@ -263,7 +275,7 @@ export default function UTRPMap(): JSX.Element {
                     <CalendarFooter />
                 </div>
                 <div className='flex p-12'>
-                    <CampusMap processedCourses={processedCourses} />
+                    <CampusMap processedCourses={processedCourses} highlightedBuildings={highlightedBuildings} />
                 </div>
 
                 {/* Show week schedule */}


### PR DESCRIPTION
Tentative PR to implement developer feature of UT Registration Plus' Map in the Calendar Header, and highlight buildings hosting courses yellow with a halo in the Map.

Linked to issue #864 and #867

<img width="1183" height="488" alt="image" src="https://github.com/user-attachments/assets/2894c77b-74ee-475f-8c4e-3b2d859c66f0" />
<img width="1395" height="83" alt="image" src="https://github.com/user-attachments/assets/de017f4d-229c-4dd3-9fef-d4c5fc6f92b0" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/868)
<!-- Reviewable:end -->
