### PR TITLE
docs: add contributors widget to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,9 @@ Special thanks to the developers and contributors behind these amazing tools and
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Longhorn-Developers/UT-Registration-Plus&type=Date" />
  </picture>
 </a>
+
+## Contributors
+
+<a href="https://github.com/pittcsc/Summer2026-Internships/graphs/contributors">
+<img src="https://contrib.rocks/image?repo=Longhorn-Developers/UT-Registration-Plus&columns=24&max=480" />
+</a>


### PR DESCRIPTION
  <a href="https://github.com/pittcsc/Summer2026-Internships/graphs/contributors">
  <img src="https://contrib.rocks/image?repo=pittcsc/Summer2025-Internships&columns=24&max=480" />
  </a>

Like this but with our heads 

<a href="https://github.com/pittcsc/Summer2026-Internships/graphs/contributors">
<img src="https://contrib.rocks/image?repo=Longhorn-Developers/UT-Registration-Plus&columns=24&max=480" />
</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/879)
<!-- Reviewable:end -->
