### PR TITLE
fix: order summer semester grades between fall and spring of same calendar year

### DIFF
--- a/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
+++ b/src/views/components/injected/CourseCatalogInjectedPopup/GradeDistribution.tsx
@@ -54,6 +54,12 @@ const GRADE_COLORS = {
     Other: extendedColors.gradeDistribution.other,
 } as const satisfies Record<LetterGrade, string>;
 
+const semesterOrdering = new Map([
+    ['Fall', 0],
+    ['Summer', 1],
+    ['Spring', 2],
+]);
+
 /**
  * Renders the grade distribution chart for a specific course.
  *
@@ -283,13 +289,16 @@ export default function GradeDistribution({ course }: GradeDistributionProps): J
                                     }
 
                                     const [season1, year1] = k1.split(' ');
-                                    const [, year2] = k2.split(' ');
+                                    const [season2, year2] = k2.split(' ');
 
                                     if (year1 !== year2) {
                                         return parseInt(year2 as string, 10) - parseInt(year1 as string, 10);
                                     }
 
-                                    return season1 === 'Fall' ? -1 : 1;
+                                    return (
+                                        (semesterOrdering.get(season1 ?? 'Fall') ?? 0) -
+                                        (semesterOrdering.get(season2 ?? 'Fall') ?? 0)
+                                    );
                                 })
                                 .map(semester => (
                                     <option key={semester} value={semester}>


### PR DESCRIPTION
Before:
<img width="155" height="182" alt="image" src="https://github.com/user-attachments/assets/56af9f94-bfde-4bfb-844b-3bb83a75c633" />

After:
<img width="149" height="172" alt="image" src="https://github.com/user-attachments/assets/4b23b21e-f42e-4e99-8fb4-5bfea761f100" />

Notice sorting of "Summer" is incorrect relevant to "Spring" in the before

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/882)
<!-- Reviewable:end -->
