### PR TITLE
test: ignore randomness in chromatic

### DIFF
--- a/src/views/components/PopupMain.tsx
+++ b/src/views/components/PopupMain.tsx
@@ -130,7 +130,7 @@ export default function PopupMain(): JSX.Element {
                 </ScheduleDropdown>
             </div>
             {activeSchedule?.courses?.length === 0 && (
-                <div className='max-w-64 flex flex-col items-center self-center gap-1.25 px-2 py-2 pt-24'>
+                <div className='max-w-64 flex flex-col items-center self-center gap-1.25 px-2 py-2 pt-24 chromatic-ignore'>
                     <Text variant='p' className='text-center text-ut-gray !font-normal'>
                         {funny}
                     </Text>


### PR DESCRIPTION
Previously, we've seen stuff like this

<img width="1768" height="918" alt="image" src="https://github.com/user-attachments/assets/216453e7-66d3-4acf-9b1f-b3d4ff6963c0" />

The reasoning is because the splash text when no courses are added is randomized.

<img width="1485" height="710" alt="image" src="https://github.com/user-attachments/assets/0249dbe2-a4de-4108-80e4-702720024205" />

This change uses the `chromatic-ignore` class https://www.chromatic.com/docs/ignoring-elements/

Notice that we use it on the outside part of the component, since the "(No courses added)" text still shifts in location due to the height of the random text.

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/892)
<!-- Reviewable:end -->
