### PR TITLE
fix: refresh upon user login using inline prompt

### DIFF
--- a/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
+++ b/src/views/components/calendar/CalendarHeader/CalendarHeader.tsx
@@ -1,4 +1,5 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import { background } from '@shared/messages';
 import { OptionsStore } from '@shared/storage/OptionsStore';
 import { UTRP_LOGIN_URL } from '@shared/util/appUrls';
 import styles from '@views/components/calendar/CalendarHeader/CalendarHeader.module.scss';
@@ -14,7 +15,7 @@ import { useActiveSchedule } from '@views/hooks/useSchedules';
 import refreshCourses from '@views/lib/refreshCourses';
 import clsx from 'clsx';
 import type { JSX } from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import ArrowsClockwiseIcon from '~icons/ph/arrows-clockwise';
 import CalendarDotsIcon from '~icons/ph/calendar-dots';
 import ExportIcon from '~icons/ph/export';
@@ -70,6 +71,22 @@ export default function CalendarHeader({ sidebarOpen, onSidebarToggle }: Calenda
             }, 3000);
         }
     }, [activeSchedule, isRefreshing]);
+
+    const handleRefreshRef = useRef(handleRefresh);
+    handleRefreshRef.current = handleRefresh;
+
+    // Retries after the user returns from the login tab, so the prompt yields to a timestamp
+    useEffect(() => {
+        if (!showLoginPrompt) return undefined;
+
+        const onVisibilityChange = async () => {
+            if (document.visibilityState !== 'visible') return;
+            if (await background.validateLoginStatus()) void handleRefreshRef.current();
+        };
+
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+    }, [showLoginPrompt]);
 
     return (
         <div


### PR DESCRIPTION
Currently, if user clicks Login hyperlink, logs in, and returns to tab, this prompt still displays:

<img width="316" height="76" alt="image" src="https://github.com/user-attachments/assets/7fd3c991-70d0-44a4-a34e-6196f81dd4b9" />

Now, upon user login after clicking this prompt, refreshCourses() runs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Longhorn-Developers/UT-Registration-Plus/894)
<!-- Reviewable:end -->
